### PR TITLE
Fix B4 (Vec binary * and / constrained to arithmetic scalars)

### DIFF
--- a/include/OpenABF/Vec.hpp
+++ b/include/OpenABF/Vec.hpp
@@ -213,8 +213,8 @@ public:
     }
 
     /** @brief Multiplication operator */
-    template <class Vector>
-    friend Vec operator*(Vec lhs, const Vector& rhs)
+    template <typename T2, std::enable_if_t<std::is_arithmetic<T2>::value, bool> = true>
+    friend Vec operator*(Vec lhs, const T2& rhs)
     {
         lhs *= rhs;
         return lhs;
@@ -231,8 +231,8 @@ public:
     }
 
     /** @brief Division operator */
-    template <class Vector>
-    friend Vec operator/(Vec lhs, const Vector& rhs)
+    template <typename T2, std::enable_if_t<std::is_arithmetic<T2>::value, bool> = true>
+    friend Vec operator/(Vec lhs, const T2& rhs)
     {
         lhs /= rhs;
         return lhs;

--- a/single_include/OpenABF/OpenABF.hpp
+++ b/single_include/OpenABF/OpenABF.hpp
@@ -365,8 +365,8 @@ public:
     }
 
     /** @brief Multiplication operator */
-    template <class Vector>
-    friend Vec operator*(Vec lhs, const Vector& rhs)
+    template <typename T2, std::enable_if_t<std::is_arithmetic<T2>::value, bool> = true>
+    friend Vec operator*(Vec lhs, const T2& rhs)
     {
         lhs *= rhs;
         return lhs;
@@ -383,8 +383,8 @@ public:
     }
 
     /** @brief Division operator */
-    template <class Vector>
-    friend Vec operator/(Vec lhs, const Vector& rhs)
+    template <typename T2, std::enable_if_t<std::is_arithmetic<T2>::value, bool> = true>
+    friend Vec operator/(Vec lhs, const T2& rhs)
     {
         lhs /= rhs;
         return lhs;
@@ -437,6 +437,7 @@ std::ostream& operator<<(std::ostream& os, const OpenABF::Vec<T, Dims>& vec)
     os << "]";
     return os;
 }
+
 
 // #include "OpenABF/HalfEdgeMesh.hpp"
 

--- a/tests/src/TestVec.cpp
+++ b/tests/src/TestVec.cpp
@@ -117,6 +117,12 @@ TEST(Vec, OperatorDivide)
     EXPECT_EQ(a, Vec3f(1, 1, 1));
 }
 
+TEST(Vec, ScalarMultiplyDivide)
+{
+    EXPECT_EQ(Vec3f(2.f, 4.f, 6.f) * 2.f, Vec3f(4.f, 8.f, 12.f));
+    EXPECT_EQ(Vec3f(4.f, 8.f, 12.f) / 2.f, Vec3f(2.f, 4.f, 6.f));
+}
+
 TEST(Vec, DotProduct)
 {
     EXPECT_EQ(Vec3f(1, 0, 0).dot(Vec3f(0, 1, 0)), 0);


### PR DESCRIPTION
## Summary

`Vec::operator*=(T2)` and `operator/=(T2)` already require `std::is_arithmetic<T2>`, but the corresponding binary `operator*` and `operator/` accepted any `Vector` type, creating an inconsistency that could silently misbehave or fail to compile with non-scalar RHS values.

**Fix:** Constrain binary `operator*` and `operator/` with `std::enable_if_t<std::is_arithmetic<T2>::value>`, matching `*=` and `/=`.

Adds `TEST(Vec, ScalarMultiplyDivide)` to verify scalar multiply/divide correctness.

## Test plan

- [x] All 6 test suites pass (`ctest` 100%)
- [x] New `ScalarMultiplyDivide` test passes
- [x] No regressions in existing Vec tests

Closes #9