### PR TITLE
Fix B5 (is_file_type bounds check) and B6 (PLY vmap validation)

### DIFF
--- a/include/OpenABF/MeshIOFormats.hpp
+++ b/include/OpenABF/MeshIOFormats.hpp
@@ -19,6 +19,9 @@ template <typename PluginType>
 static auto is_file_type(const std::filesystem::path& path)
 {
     auto ext = path.extension().string();
+    if (ext.empty()) {
+        return false;
+    }
     if (ext[0] == '.') {
         ext = ext.substr(1);
     }
@@ -254,6 +257,7 @@ struct PLY {
         // Set up vertex map: v[n] -> property[m]
         // Probably unnecessary
         std::array<std::size_t, 3> vmap{};
+        std::array<bool, 3> vmapFound{false, false, false};
         auto v_elem = std::find_if(elements.begin(), elements.end(),
                                    [](const auto& e) { return e.label == "vertex"; });
         if (v_elem == elements.end()) {
@@ -262,11 +266,17 @@ struct PLY {
         for (auto i = 0; i < v_elem->properties.size(); ++i) {
             if (const auto& prop = v_elem->properties[i]; prop.label == "x") {
                 vmap[0] = i;
+                vmapFound[0] = true;
             } else if (prop.label == "y") {
                 vmap[1] = i;
+                vmapFound[1] = true;
             } else if (prop.label == "z") {
                 vmap[2] = i;
+                vmapFound[2] = true;
             }
+        }
+        if (!vmapFound[0] || !vmapFound[1] || !vmapFound[2]) {
+            throw std::runtime_error("PLY vertex element missing required x/y/z properties");
         }
 
         // Iterate the lines of the body

--- a/single_include/OpenABF/OpenABF.hpp
+++ b/single_include/OpenABF/OpenABF.hpp
@@ -3129,6 +3129,9 @@ template <typename PluginType>
 static auto is_file_type(const std::filesystem::path& path)
 {
     auto ext = path.extension().string();
+    if (ext.empty()) {
+        return false;
+    }
     if (ext[0] == '.') {
         ext = ext.substr(1);
     }
@@ -3364,6 +3367,7 @@ struct PLY {
         // Set up vertex map: v[n] -> property[m]
         // Probably unnecessary
         std::array<std::size_t, 3> vmap{};
+        std::array<bool, 3> vmapFound{false, false, false};
         auto v_elem = std::find_if(elements.begin(), elements.end(),
                                    [](const auto& e) { return e.label == "vertex"; });
         if (v_elem == elements.end()) {
@@ -3372,11 +3376,17 @@ struct PLY {
         for (auto i = 0; i < v_elem->properties.size(); ++i) {
             if (const auto& prop = v_elem->properties[i]; prop.label == "x") {
                 vmap[0] = i;
+                vmapFound[0] = true;
             } else if (prop.label == "y") {
                 vmap[1] = i;
+                vmapFound[1] = true;
             } else if (prop.label == "z") {
                 vmap[2] = i;
+                vmapFound[2] = true;
             }
+        }
+        if (!vmapFound[0] || !vmapFound[1] || !vmapFound[2]) {
+            throw std::runtime_error("PLY vertex element missing required x/y/z properties");
         }
 
         // Iterate the lines of the body

--- a/tests/src/TestMeshIO.cpp
+++ b/tests/src/TestMeshIO.cpp
@@ -98,3 +98,28 @@ TEST(MeshIO, UnsupportedFileType)
     EXPECT_THROW(WriteMesh("test.unknown", mesh), std::runtime_error);
     EXPECT_THROW(ReadMesh<MeshType>("test.unknown"), std::runtime_error);
 }
+
+TEST(MeshIO, IsFileTypeNoExtension)
+{
+    EXPECT_FALSE(io_formats::is_file_type<io_formats::OBJ>("mesh"));
+    EXPECT_FALSE(io_formats::is_file_type<io_formats::PLY>("mesh"));
+}
+
+TEST(MeshIO, PLY_MissingVertexProperty)
+{
+    // PLY header with x and y but missing z property
+    std::string ply_data =
+        "ply\n"
+        "format ascii 1.0\n"
+        "element vertex 1\n"
+        "property float x\n"
+        "property float y\n"
+        "element face 0\n"
+        "property list uchar int vertex_indices\n"
+        "end_header\n"
+        "1.0 2.0\n";
+
+    std::istringstream iss(ply_data);
+    auto mesh = MeshType::New();
+    EXPECT_THROW(io_formats::PLY::Read(iss, *mesh), std::runtime_error);
+}


### PR DESCRIPTION
## Summary

- **B5**: `is_file_type` in `MeshIOFormats.hpp` called `ext[0]` on `path.extension().string()` without checking if the string was empty, causing undefined behavior for paths with no extension (e.g. `"mesh"`). Added an `ext.empty()` guard that returns `false` early.

- **B6**: The PLY reader initialized `vmap{}` to `{0,0,0}`. If the PLY header was missing any of the `x`, `y`, or `z` vertex properties, the missing indices silently stayed at 0, causing reads from the wrong data column. Added a `vmapFound` tracking array and validation that throws `std::runtime_error` if any of x/y/z are absent.

Adds two new tests:
- `MeshIO.IsFileTypeNoExtension` — asserts no-extension path returns false without UB
- `MeshIO.PLY_MissingVertexProperty` — asserts `std::runtime_error` for a PLY with missing `z`

## Test plan

- [x] All 6 test suites pass (`ctest` 100%)
- [x] Both new tests pass
- [x] All existing IO tests pass

Closes #10
Closes #11