### PR TITLE
Fix M4 (operator<< moved inside OpenABF namespace)

### DIFF
--- a/include/OpenABF/Vec.hpp
+++ b/include/OpenABF/Vec.hpp
@@ -268,11 +268,9 @@ using Vec3f = Vec<float, 3>;
 /** @brief 3D, 64-bit float vector */
 using Vec3d = Vec<double, 3>;
 
-}  // namespace OpenABF
-
 /** Debug: Print a vector to a std::ostream */
 template <typename T, std::size_t Dims>
-std::ostream& operator<<(std::ostream& os, const OpenABF::Vec<T, Dims>& vec)
+std::ostream& operator<<(std::ostream& os, const Vec<T, Dims>& vec)
 {
     os << "[";
     std::size_t i{0};
@@ -285,3 +283,5 @@ std::ostream& operator<<(std::ostream& os, const OpenABF::Vec<T, Dims>& vec)
     os << "]";
     return os;
 }
+
+}  // namespace OpenABF

--- a/single_include/OpenABF/OpenABF.hpp
+++ b/single_include/OpenABF/OpenABF.hpp
@@ -420,11 +420,9 @@ using Vec3f = Vec<float, 3>;
 /** @brief 3D, 64-bit float vector */
 using Vec3d = Vec<double, 3>;
 
-}  // namespace OpenABF
-
 /** Debug: Print a vector to a std::ostream */
 template <typename T, std::size_t Dims>
-std::ostream& operator<<(std::ostream& os, const OpenABF::Vec<T, Dims>& vec)
+std::ostream& operator<<(std::ostream& os, const Vec<T, Dims>& vec)
 {
     os << "[";
     std::size_t i{0};
@@ -437,6 +435,8 @@ std::ostream& operator<<(std::ostream& os, const OpenABF::Vec<T, Dims>& vec)
     os << "]";
     return os;
 }
+
+}  // namespace OpenABF
 
 
 // #include "OpenABF/HalfEdgeMesh.hpp"


### PR DESCRIPTION
## Summary

`operator<<` for `Vec` was defined after the closing brace of the `OpenABF` namespace. While ADL handles this in practice, it is cleaner and more correct to define it inside the namespace. Moved the definition inside `OpenABF`, removing the now-unnecessary `OpenABF::` qualification from the parameter type.

## Test plan

- [x] All 6 test suites pass (`ctest` 100%)
- [x] No change in observable behavior

Closes #28