### PR TITLE
Fix M1 (barycenter return type) and M2 (magnitude const)

### DIFF
--- a/include/OpenABF/HalfEdgeMesh.hpp
+++ b/include/OpenABF/HalfEdgeMesh.hpp
@@ -493,7 +493,7 @@ public:
         [[nodiscard]] auto is_boundary() const -> bool { return face == nullptr; }
 
         /** @brief Edge length */
-        auto magnitude() -> T { return (pair->vertex->pos - vertex->pos).magnitude(); }
+        auto magnitude() const -> T { return (pair->vertex->pos - vertex->pos).magnitude(); }
 
         /** @brief This edge's adjacent half-edge */
         EdgePtr pair;
@@ -569,7 +569,7 @@ public:
         }
 
         /** @brief Face barycenter (center-of-mass) */
-        auto barycenter() const -> Vec<T, 3>
+        auto barycenter() const -> Vec<T, Dim>
         {
             return (head->vertex->pos + head->next->vertex->pos + head->prev->vertex->pos) / T(3);
         }

--- a/single_include/OpenABF/OpenABF.hpp
+++ b/single_include/OpenABF/OpenABF.hpp
@@ -937,7 +937,7 @@ public:
         [[nodiscard]] auto is_boundary() const -> bool { return face == nullptr; }
 
         /** @brief Edge length */
-        auto magnitude() -> T { return (pair->vertex->pos - vertex->pos).magnitude(); }
+        auto magnitude() const -> T { return (pair->vertex->pos - vertex->pos).magnitude(); }
 
         /** @brief This edge's adjacent half-edge */
         EdgePtr pair;
@@ -1013,7 +1013,7 @@ public:
         }
 
         /** @brief Face barycenter (center-of-mass) */
-        auto barycenter() const -> Vec<T, 3>
+        auto barycenter() const -> Vec<T, Dim>
         {
             return (head->vertex->pos + head->next->vertex->pos + head->prev->vertex->pos) / T(3);
         }


### PR DESCRIPTION
## Summary

- **M1**: `Face::barycenter()` returned `Vec<T, 3>` regardless of the mesh's `Dim` template parameter. Changed return type to `Vec<T, Dim>`.
- **M2**: `Edge::magnitude()` only reads vertex positions but was not declared `const`, preventing use on const-qualified edge references. Added `const`.

Note: M3 (`detail::erase_if` removal) was found to have 6 active call sites in `HalfEdgeMesh.hpp` — the spec incorrectly described it as dead code. M3 will need a separate investigation.

## Test plan

- [x] All 6 test suites pass (`ctest` 100%)
- [x] No regressions

Closes #25
Closes #26