### PR TITLE
Fix M3: rename detail::erase_if to detail::filter

### DIFF
--- a/conductor/tracks/M3/spec.md
+++ b/conductor/tracks/M3/spec.md
@@ -10,11 +10,14 @@ returns it — making it a *filtered copy* utility. This conflicts with the name
 function has 6 active call sites in `HalfEdgeMesh.hpp` (lines 800, 813, 1094,
 1096, 1117, 1119), all of which correctly capture the return value.
 
+## Accepted Approach
+Rename `detail::erase_if` → `detail::filter`. The library targets C++17, so
+`std::erase_if` (C++20) and `std::ranges::filter_view` are unavailable; keeping
+a named helper is appropriate. The rename makes the copy semantics self-evident.
+
 ## Acceptance Criteria
-- [ ] Either rename `detail::erase_if` to a name that reflects copy semantics
-  (e.g. `detail::filter` or `detail::filtered_copy`), or replace all 6 call
-  sites with inline `std::copy_if` / `std::ranges::filter_view` and remove the
-  helper
+- [ ] `detail::erase_if` renamed to `detail::filter` in `HalfEdgeMesh.hpp`
+- [ ] All 6 call sites updated
 - [ ] All tests pass
 - [ ] No change in behavior at any call site
 

--- a/include/OpenABF/HalfEdgeMesh.hpp
+++ b/include/OpenABF/HalfEdgeMesh.hpp
@@ -56,7 +56,7 @@ auto vec_to_string(const T& v) -> std::string
 
 /** Remove elements which meet the given predicate */
 template <class ForwardContainer, class UnaryPred>
-auto erase_if(ForwardContainer v, UnaryPred p)
+auto filter(ForwardContainer v, UnaryPred p)
 {
     auto end = std::remove_if(std::begin(v), std::end(v), p);
     v.erase(end, std::end(v));
@@ -797,8 +797,8 @@ public:
             if (edge->is_boundary()) {
                 // Get incoming boundary edges to the start point
                 auto inBoundary =
-                    detail::erase_if(incoming_edges(edge->vertex->idx),
-                                     [](const auto& e) { return not e->is_boundary(); });
+                    detail::filter(incoming_edges(edge->vertex->idx),
+                                   [](const auto& e) { return not e->is_boundary(); });
                 if (inBoundary.size() == 0 or inBoundary.size() > 1) {
                     const std::array<std::size_t, 2> idx{edge->vertex->idx,
                                                          edge->pair->vertex->idx};
@@ -810,8 +810,8 @@ public:
 
                 // Get outgoing boundary edges to the end point
                 auto outBoundary =
-                    detail::erase_if(outgoing_edges(edge->pair->vertex->idx),
-                                     [](const auto& e) { return not e->is_boundary(); });
+                    detail::filter(outgoing_edges(edge->pair->vertex->idx),
+                                   [](const auto& e) { return not e->is_boundary(); });
                 if (outBoundary.size() == 0 or outBoundary.size() > 1) {
                     const std::array<std::size_t, 2> idx{edge->vertex->idx,
                                                          edge->pair->vertex->idx};
@@ -1091,10 +1091,10 @@ public:
             auto newIdx = insert_vertex(oldStart->pos);
             newStart = verts_.at(newIdx);
 
-            auto in = detail::erase_if(incoming_edges(oldStart->idx),
-                                       [](auto e) { return not e->is_boundary(); });
-            auto out = detail::erase_if(outgoing_edges(oldStart->idx),
-                                        [](auto e) { return not e->is_boundary(); });
+            auto in = detail::filter(incoming_edges(oldStart->idx),
+                                     [](auto e) { return not e->is_boundary(); });
+            auto out = detail::filter(outgoing_edges(oldStart->idx),
+                                      [](auto e) { return not e->is_boundary(); });
             if (in.size() == 0 or out.size() == 0) {
                 throw MeshException("No incoming/outgoing edges");
             }
@@ -1114,10 +1114,10 @@ public:
             auto newIdx = insert_vertex(oldEnd->pos);
             newEnd = verts_.at(newIdx);
 
-            auto in = detail::erase_if(incoming_edges(oldEnd->idx),
-                                       [](auto e) { return not e->is_boundary(); });
-            auto out = detail::erase_if(outgoing_edges(oldEnd->idx),
-                                        [](auto e) { return not e->is_boundary(); });
+            auto in = detail::filter(incoming_edges(oldEnd->idx),
+                                     [](auto e) { return not e->is_boundary(); });
+            auto out = detail::filter(outgoing_edges(oldEnd->idx),
+                                      [](auto e) { return not e->is_boundary(); });
             if (in.size() == 0 or out.size() == 0) {
                 throw MeshException("No incoming/outgoing edges");
             }

--- a/single_include/OpenABF/OpenABF.hpp
+++ b/single_include/OpenABF/OpenABF.hpp
@@ -500,7 +500,7 @@ auto vec_to_string(const T& v) -> std::string
 
 /** Remove elements which meet the given predicate */
 template <class ForwardContainer, class UnaryPred>
-auto erase_if(ForwardContainer v, UnaryPred p)
+auto filter(ForwardContainer v, UnaryPred p)
 {
     auto end = std::remove_if(std::begin(v), std::end(v), p);
     v.erase(end, std::end(v));
@@ -1241,8 +1241,8 @@ public:
             if (edge->is_boundary()) {
                 // Get incoming boundary edges to the start point
                 auto inBoundary =
-                    detail::erase_if(incoming_edges(edge->vertex->idx),
-                                     [](const auto& e) { return not e->is_boundary(); });
+                    detail::filter(incoming_edges(edge->vertex->idx),
+                                   [](const auto& e) { return not e->is_boundary(); });
                 if (inBoundary.size() == 0 or inBoundary.size() > 1) {
                     const std::array<std::size_t, 2> idx{edge->vertex->idx,
                                                          edge->pair->vertex->idx};
@@ -1254,8 +1254,8 @@ public:
 
                 // Get outgoing boundary edges to the end point
                 auto outBoundary =
-                    detail::erase_if(outgoing_edges(edge->pair->vertex->idx),
-                                     [](const auto& e) { return not e->is_boundary(); });
+                    detail::filter(outgoing_edges(edge->pair->vertex->idx),
+                                   [](const auto& e) { return not e->is_boundary(); });
                 if (outBoundary.size() == 0 or outBoundary.size() > 1) {
                     const std::array<std::size_t, 2> idx{edge->vertex->idx,
                                                          edge->pair->vertex->idx};
@@ -1535,10 +1535,10 @@ public:
             auto newIdx = insert_vertex(oldStart->pos);
             newStart = verts_.at(newIdx);
 
-            auto in = detail::erase_if(incoming_edges(oldStart->idx),
-                                       [](auto e) { return not e->is_boundary(); });
-            auto out = detail::erase_if(outgoing_edges(oldStart->idx),
-                                        [](auto e) { return not e->is_boundary(); });
+            auto in = detail::filter(incoming_edges(oldStart->idx),
+                                     [](auto e) { return not e->is_boundary(); });
+            auto out = detail::filter(outgoing_edges(oldStart->idx),
+                                      [](auto e) { return not e->is_boundary(); });
             if (in.size() == 0 or out.size() == 0) {
                 throw MeshException("No incoming/outgoing edges");
             }
@@ -1558,10 +1558,10 @@ public:
             auto newIdx = insert_vertex(oldEnd->pos);
             newEnd = verts_.at(newIdx);
 
-            auto in = detail::erase_if(incoming_edges(oldEnd->idx),
-                                       [](auto e) { return not e->is_boundary(); });
-            auto out = detail::erase_if(outgoing_edges(oldEnd->idx),
-                                        [](auto e) { return not e->is_boundary(); });
+            auto in = detail::filter(incoming_edges(oldEnd->idx),
+                                     [](auto e) { return not e->is_boundary(); });
+            auto out = detail::filter(outgoing_edges(oldEnd->idx),
+                                      [](auto e) { return not e->is_boundary(); });
             if (in.size() == 0 or out.size() == 0) {
                 throw MeshException("No incoming/outgoing edges");
             }


### PR DESCRIPTION
## Summary

`detail::erase_if` takes its container by value, filters it, and returns the filtered copy. The name conflicts with `std::erase_if` (C++20), which mutates in-place — misleading any reader familiar with the standard algorithm.

Renamed to `detail::filter` to accurately reflect the copy semantics. The library targets C++17, so keeping a named helper is appropriate in lieu of `std::ranges::filter_view`.

All 7 occurrences updated (1 definition + 6 call sites in `HalfEdgeMesh.hpp`). No behavioral change.

## Test plan

- [x] All 6 test suites pass (`ctest` 100%)
- [x] No change in behavior

Closes #27