### PR TITLE
perf: replace vector-returning iteration methods with lazy ranges (P1 + A2)

### DIFF
--- a/conductor/tracks.md
+++ b/conductor/tracks.md
@@ -9,11 +9,11 @@
 | closed | B5 | `is_file_type` accesses `ext[0]` without bounds check | [#10](https://github.com/educelab/OpenABF/issues/10) | 2026-03-13 | 2026-03-15 |
 | closed | B6 | PLY reader vmap silently uninitialized if x/y/z absent | [#11](https://github.com/educelab/OpenABF/issues/11) | 2026-03-13 | 2026-03-15 |
 | closed | B7 | PlanGrad allocates and discards wheel vector | [#12](https://github.com/educelab/OpenABF/issues/12) | 2026-03-13 | 2026-03-15 |
-| open | P1 | Mesh iteration methods return `std::vector` by value | [#4](https://github.com/educelab/OpenABF/issues/4) | 2026-03-13 | 2026-03-13 |
+| closed | P1 | Mesh iteration methods return `std::vector` by value | [#4](https://github.com/educelab/OpenABF/issues/4) | 2026-03-13 | 2026-03-16 |
 | open | P2 | `std::map` for interior-vertex index lookup in solver | [#13](https://github.com/educelab/OpenABF/issues/13) | 2026-03-13 | 2026-03-13 |
-| open | P3 | `InitializeAnglesAndWeights` calls wheel() redundantly | [#14](https://github.com/educelab/OpenABF/issues/14) | 2026-03-13 | 2026-03-13 |
+| closed | P3 | `InitializeAnglesAndWeights` calls wheel() redundantly | [#14](https://github.com/educelab/OpenABF/issues/14) | 2026-03-13 | 2026-03-16 |
 | open | A1 | Convergence tolerance hardcoded in ABF and ABFPlusPlus | [#15](https://github.com/educelab/OpenABF/issues/15) | 2026-03-13 | 2026-03-13 |
-| open | A2 | FacePtr range iteration requires `*face` dereference | [#4](https://github.com/educelab/OpenABF/issues/4) | 2026-03-13 | 2026-03-13 |
+| closed | A2 | FacePtr range iteration requires `*face` dereference | [#4](https://github.com/educelab/OpenABF/issues/4) | 2026-03-13 | 2026-03-16 |
 | open | A3 | `insert_face` boundary update behavior undocumented | [#16](https://github.com/educelab/OpenABF/issues/16) | 2026-03-13 | 2026-03-13 |
 | open | A4 | `gradient()` missing `[[nodiscard]]` | [#17](https://github.com/educelab/OpenABF/issues/17) | 2026-03-13 | 2026-03-13 |
 | open | A5 | No configurable pinned edge selection for LSCM | [#2](https://github.com/educelab/OpenABF/issues/2) | 2026-03-13 | 2026-03-13 |

--- a/include/OpenABF/AngleBasedLSCM.hpp
+++ b/include/OpenABF/AngleBasedLSCM.hpp
@@ -117,7 +117,7 @@ public:
 
         // Pinned vertex selection
         // Get the end points of a boundary edge
-        auto p0 = mesh->vertices_boundary()[0];
+        auto p0 = mesh->vertices_boundary().front();
         auto e = p0->edge;
         do {
             if (e->pair->is_boundary()) {

--- a/include/OpenABF/HalfEdgeMesh.hpp
+++ b/include/OpenABF/HalfEdgeMesh.hpp
@@ -62,6 +62,73 @@ auto filter(ForwardContainer v, UnaryPred p)
     v.erase(end, std::end(v));
     return v;
 }
+
+/**
+ * @brief Lightweight non-owning range adapter holding begin/end iterators
+ *
+ * Supports range-based for loops, empty(), and front(). Used as the return
+ * type for lazy mesh iteration methods.
+ */
+template <typename Iter>
+struct Range {
+    Iter first_;
+    Iter last_;
+    auto begin() const -> Iter { return first_; }
+    auto end() const -> Iter { return last_; }
+    auto empty() const -> bool { return first_ == last_; }
+    auto front() const -> decltype(*first_) { return *first_; }
+};
+
+/**
+ * @brief Input iterator that skips elements not matching a predicate
+ *
+ * Wraps a base iterator and advances automatically past elements for which
+ * pred(*it) is false.
+ */
+template <typename Iter, typename Pred>
+class FilteringIterator
+{
+public:
+    using difference_type = std::ptrdiff_t;
+    using value_type = typename std::iterator_traits<Iter>::value_type;
+    using pointer = typename std::iterator_traits<Iter>::pointer;
+    using reference = typename std::iterator_traits<Iter>::reference;
+    using iterator_category = std::input_iterator_tag;
+
+    FilteringIterator() = default;
+    FilteringIterator(Iter current, Iter end, Pred pred) : current_{current}, end_{end}, pred_{pred}
+    {
+        advance_to_next();
+    }
+
+    auto operator*() const -> reference { return *current_; }
+    auto operator->() const -> pointer { return &*current_; }
+
+    auto operator++() -> FilteringIterator&
+    {
+        ++current_;
+        advance_to_next();
+        return *this;
+    }
+
+    auto operator==(const FilteringIterator& other) const -> bool
+    {
+        return current_ == other.current_;
+    }
+    auto operator!=(const FilteringIterator& other) const -> bool { return !(*this == other); }
+
+private:
+    void advance_to_next()
+    {
+        while (current_ != end_ && !pred_(*current_)) {
+            ++current_;
+        }
+    }
+
+    Iter current_{};
+    Iter end_{};
+    Pred pred_{};
+};
 }  // namespace detail
 
 /**
@@ -379,6 +446,175 @@ private:
         EdgePtr current_;
     };
 
+    /**
+     * @brief Iterator for the edges of a vertex's wheel
+     *
+     * Walks the half-edge linked-list around a vertex (`edge->pair->next`),
+     * yielding only non-boundary edges. Multi-pass safe: constructing a new
+     * WheelIterator from the same vertex edge always starts at the beginning.
+     *
+     * @tparam Const If true, is a const iterator
+     */
+    template <bool Const = false>
+    class WheelIterator
+    {
+    public:
+        /** Difference type */
+        using difference_type = std::ptrdiff_t;
+        /** Value type */
+        using value_type = EdgePtr;
+        /** Pointer type */
+        using pointer = std::conditional_t<Const, value_type const*, value_type*>;
+        /** Reference type */
+        using reference = std::conditional_t<Const, value_type const&, value_type&>;
+        /** Iterator category */
+        using iterator_category = std::input_iterator_tag;
+
+        /** Default constructor == End iterator (current_ == nullptr) */
+        WheelIterator() = default;
+        /** Construct from the vertex's stored edge */
+        explicit WheelIterator(const EdgePtr& head) : head_{head}, current_{head}
+        {
+            advance_to_non_boundary();
+        }
+
+        /** Dereference */
+        template <bool C = Const>
+        auto operator*() const -> std::enable_if_t<C, reference>
+        {
+            return current_;
+        }
+        template <bool C = Const>
+        auto operator*() -> std::enable_if_t<!C, reference>
+        {
+            return current_;
+        }
+
+        /** Equality */
+        auto operator==(const WheelIterator& other) const -> bool
+        {
+            return current_ == other.current_;
+        }
+        /** Inequality */
+        auto operator!=(const WheelIterator& other) const -> bool { return !(*this == other); }
+
+        /** Increment */
+        auto operator++() -> WheelIterator&
+        {
+            if (!current_) {
+                return *this;
+            }
+            current_ = current_->pair->next;
+            if (current_ == head_) {
+                current_ = nullptr;
+                return *this;
+            }
+            advance_to_non_boundary();
+            return *this;
+        }
+
+    private:
+        void advance_to_non_boundary()
+        {
+            while (current_ && current_->is_boundary()) {
+                current_ = current_->pair->next;
+                if (current_ == head_) {
+                    current_ = nullptr;
+                    break;
+                }
+            }
+        }
+
+        EdgePtr head_{};
+        EdgePtr current_{};
+    };
+
+    /**
+     * @brief Iterator that lazily flattens all face edges across all faces
+     *
+     * Provides a single flat sequence over all face (non-boundary) edges in
+     * the mesh without allocating a vector. Internally advances through
+     * `faces_` and uses `FaceIterator` within each face.
+     *
+     * @tparam Const If true, is a const iterator
+     */
+    template <bool Const = false>
+    class EdgesIterator
+    {
+    public:
+        /** Difference type */
+        using difference_type = std::ptrdiff_t;
+        /** Value type */
+        using value_type = EdgePtr;
+        /** Pointer type */
+        using pointer = std::conditional_t<Const, value_type const*, value_type*>;
+        /** Reference type */
+        using reference = std::conditional_t<Const, value_type const&, value_type&>;
+        /** Iterator category */
+        using iterator_category = std::input_iterator_tag;
+
+        using FaceVecIter = typename std::vector<FacePtr>::const_iterator;
+
+        /** Construct at position (begin or end depending on faceIt == faceEnd) */
+        EdgesIterator(FaceVecIter faceIt, FaceVecIter faceEnd) : faceIt_{faceIt}, faceEnd_{faceEnd}
+        {
+            if (faceIt_ != faceEnd_) {
+                edgeIt_ = FaceIterator<true>{(*faceIt_)->head, (*faceIt_)->head};
+                advance_if_face_exhausted();
+            }
+        }
+
+        /** Dereference */
+        template <bool C = Const>
+        auto operator*() const -> std::enable_if_t<C, reference>
+        {
+            return *edgeIt_;
+        }
+        template <bool C = Const>
+        auto operator*() -> std::enable_if_t<!C, reference>
+        {
+            return *edgeIt_;
+        }
+
+        /** Equality */
+        auto operator==(const EdgesIterator& other) const -> bool
+        {
+            // Both exhausted (at end)
+            if (faceIt_ == faceEnd_ && other.faceIt_ == other.faceEnd_) {
+                return true;
+            }
+            if (faceIt_ != other.faceIt_) {
+                return false;
+            }
+            return edgeIt_ == other.edgeIt_;
+        }
+        /** Inequality */
+        auto operator!=(const EdgesIterator& other) const -> bool { return !(*this == other); }
+
+        /** Increment */
+        auto operator++() -> EdgesIterator&
+        {
+            ++edgeIt_;
+            advance_if_face_exhausted();
+            return *this;
+        }
+
+    private:
+        void advance_if_face_exhausted()
+        {
+            while (edgeIt_ == FaceIterator<true>() && faceIt_ != faceEnd_) {
+                ++faceIt_;
+                if (faceIt_ != faceEnd_) {
+                    edgeIt_ = FaceIterator<true>{(*faceIt_)->head, (*faceIt_)->head};
+                }
+            }
+        }
+
+        FaceVecIter faceIt_{};
+        FaceVecIter faceEnd_{};
+        FaceIterator<true> edgeIt_{};
+    };
+
 public:
     /** @brief %Vertex type */
     struct Vertex : VertexTraits {
@@ -406,17 +642,10 @@ public:
          *
          * @throws MeshException If vertex is a boundary vertex.
          */
-        auto wheel() const -> std::vector<EdgePtr>
+        auto wheel() const
         {
-            std::vector<EdgePtr> ret;
-            auto e = edge;
-            do {
-                if (not e->is_boundary()) {
-                    ret.emplace_back(e);
-                }
-                e = e->pair->next;
-            } while (e != edge);
-            return ret;
+            using Iter = WheelIterator<true>;
+            return detail::Range<Iter>{Iter{edge}, Iter{}};
         }
 
         /** @brief Unit vertex normal */
@@ -550,6 +779,12 @@ public:
         const_iterator cbegin() const { return const_iterator{head, head}; }
         /** @brief Returns the const end iterator */
         const_iterator cend() const { return const_iterator(); }
+        /** @brief Returns an iterable range over the edges of the face (resolves A2) */
+        auto edges() const
+        {
+            using Iter = const_iterator;
+            return detail::Range<Iter>{Iter{head, head}, Iter{}};
+        }
 
         /** @brief Area of the face */
         auto area() const -> T
@@ -830,21 +1065,17 @@ public:
     }
 
     /** @brief Get the list of vertices in insertion order */
-    auto vertices() const -> std::vector<VertPtr> { return verts_; }
+    auto vertices() const -> const std::vector<VertPtr>& { return verts_; }
 
     /** @brief Get a vertex by index */
     auto vertex(std::size_t idx) const -> VertPtr { return verts_.at(idx); }
 
-    /** @brief Get the list of face edges in insertion order */
-    auto edges() const -> std::vector<EdgePtr>
+    /** @brief Get a lazy range over all face edges in insertion order */
+    auto edges() const
     {
-        std::vector<EdgePtr> edges;
-        for (const auto& f : faces_) {
-            for (const auto& e : *f) {
-                edges.emplace_back(e);
-            }
-        }
-        return edges;
+        using Iter = EdgesIterator<true>;
+        return detail::Range<Iter>{Iter{faces_.cbegin(), faces_.cend()},
+                                   Iter{faces_.cend(), faces_.cend()}};
     }
 
     /** @brief Find an existing edge with the provided end points */
@@ -916,7 +1147,7 @@ public:
     }
 
     /** @brief Get the list of faces in insertion order */
-    auto faces() const -> std::vector<FacePtr> { return faces_; }
+    auto faces() const -> const std::vector<FacePtr>& { return faces_; }
 
     /** @brief Get a face by index */
     auto face(std::size_t idx) const -> FacePtr { return faces_.at(idx); }
@@ -1009,21 +1240,23 @@ public:
     }
 
     /** @brief Get the list of interior vertices in insertion order */
-    auto vertices_interior() const -> std::vector<VertPtr>
+    auto vertices_interior() const
     {
-        std::vector<VertPtr> ret;
-        std::copy_if(verts_.begin(), verts_.end(), std::back_inserter(ret),
-                     [](auto x) { return not x->is_boundary(); });
-        return ret;
+        auto pred = [](const VertPtr& v) { return not v->is_boundary(); };
+        using BaseIter = typename std::vector<VertPtr>::const_iterator;
+        using Iter = detail::FilteringIterator<BaseIter, decltype(pred)>;
+        return detail::Range<Iter>{Iter{verts_.cbegin(), verts_.cend(), pred},
+                                   Iter{verts_.cend(), verts_.cend(), pred}};
     }
 
-    /** @brief Get the list of boundary vertices in insertion order */
-    auto vertices_boundary() const -> std::vector<VertPtr>
+    /** @brief Get a lazy range over boundary vertices in insertion order */
+    auto vertices_boundary() const
     {
-        std::vector<VertPtr> ret;
-        std::copy_if(verts_.begin(), verts_.end(), std::back_inserter(ret),
-                     [](auto x) { return x->is_boundary(); });
-        return ret;
+        auto pred = [](const VertPtr& v) { return v->is_boundary(); };
+        using BaseIter = typename std::vector<VertPtr>::const_iterator;
+        using Iter = detail::FilteringIterator<BaseIter, decltype(pred)>;
+        return detail::Range<Iter>{Iter{verts_.cbegin(), verts_.cend(), pred},
+                                   Iter{verts_.cend(), verts_.cend(), pred}};
     }
 
     /** @brief Get the number of vertices */

--- a/include/OpenABF/HalfEdgeMesh.hpp
+++ b/include/OpenABF/HalfEdgeMesh.hpp
@@ -779,7 +779,7 @@ public:
         const_iterator cbegin() const { return const_iterator{head, head}; }
         /** @brief Returns the const end iterator */
         const_iterator cend() const { return const_iterator(); }
-        /** @brief Returns an iterable range over the edges of the face (resolves A2) */
+        /** @brief Returns an iterable range over the edges of the face */
         auto edges() const
         {
             using Iter = const_iterator;

--- a/single_include/OpenABF/OpenABF.hpp
+++ b/single_include/OpenABF/OpenABF.hpp
@@ -506,6 +506,73 @@ auto filter(ForwardContainer v, UnaryPred p)
     v.erase(end, std::end(v));
     return v;
 }
+
+/**
+ * @brief Lightweight non-owning range adapter holding begin/end iterators
+ *
+ * Supports range-based for loops, empty(), and front(). Used as the return
+ * type for lazy mesh iteration methods.
+ */
+template <typename Iter>
+struct Range {
+    Iter first_;
+    Iter last_;
+    auto begin() const -> Iter { return first_; }
+    auto end() const -> Iter { return last_; }
+    auto empty() const -> bool { return first_ == last_; }
+    auto front() const -> decltype(*first_) { return *first_; }
+};
+
+/**
+ * @brief Input iterator that skips elements not matching a predicate
+ *
+ * Wraps a base iterator and advances automatically past elements for which
+ * pred(*it) is false.
+ */
+template <typename Iter, typename Pred>
+class FilteringIterator
+{
+public:
+    using difference_type = std::ptrdiff_t;
+    using value_type = typename std::iterator_traits<Iter>::value_type;
+    using pointer = typename std::iterator_traits<Iter>::pointer;
+    using reference = typename std::iterator_traits<Iter>::reference;
+    using iterator_category = std::input_iterator_tag;
+
+    FilteringIterator() = default;
+    FilteringIterator(Iter current, Iter end, Pred pred) : current_{current}, end_{end}, pred_{pred}
+    {
+        advance_to_next();
+    }
+
+    auto operator*() const -> reference { return *current_; }
+    auto operator->() const -> pointer { return &*current_; }
+
+    auto operator++() -> FilteringIterator&
+    {
+        ++current_;
+        advance_to_next();
+        return *this;
+    }
+
+    auto operator==(const FilteringIterator& other) const -> bool
+    {
+        return current_ == other.current_;
+    }
+    auto operator!=(const FilteringIterator& other) const -> bool { return !(*this == other); }
+
+private:
+    void advance_to_next()
+    {
+        while (current_ != end_ && !pred_(*current_)) {
+            ++current_;
+        }
+    }
+
+    Iter current_{};
+    Iter end_{};
+    Pred pred_{};
+};
 }  // namespace detail
 
 /**
@@ -823,6 +890,175 @@ private:
         EdgePtr current_;
     };
 
+    /**
+     * @brief Iterator for the edges of a vertex's wheel
+     *
+     * Walks the half-edge linked-list around a vertex (`edge->pair->next`),
+     * yielding only non-boundary edges. Multi-pass safe: constructing a new
+     * WheelIterator from the same vertex edge always starts at the beginning.
+     *
+     * @tparam Const If true, is a const iterator
+     */
+    template <bool Const = false>
+    class WheelIterator
+    {
+    public:
+        /** Difference type */
+        using difference_type = std::ptrdiff_t;
+        /** Value type */
+        using value_type = EdgePtr;
+        /** Pointer type */
+        using pointer = std::conditional_t<Const, value_type const*, value_type*>;
+        /** Reference type */
+        using reference = std::conditional_t<Const, value_type const&, value_type&>;
+        /** Iterator category */
+        using iterator_category = std::input_iterator_tag;
+
+        /** Default constructor == End iterator (current_ == nullptr) */
+        WheelIterator() = default;
+        /** Construct from the vertex's stored edge */
+        explicit WheelIterator(const EdgePtr& head) : head_{head}, current_{head}
+        {
+            advance_to_non_boundary();
+        }
+
+        /** Dereference */
+        template <bool C = Const>
+        auto operator*() const -> std::enable_if_t<C, reference>
+        {
+            return current_;
+        }
+        template <bool C = Const>
+        auto operator*() -> std::enable_if_t<!C, reference>
+        {
+            return current_;
+        }
+
+        /** Equality */
+        auto operator==(const WheelIterator& other) const -> bool
+        {
+            return current_ == other.current_;
+        }
+        /** Inequality */
+        auto operator!=(const WheelIterator& other) const -> bool { return !(*this == other); }
+
+        /** Increment */
+        auto operator++() -> WheelIterator&
+        {
+            if (!current_) {
+                return *this;
+            }
+            current_ = current_->pair->next;
+            if (current_ == head_) {
+                current_ = nullptr;
+                return *this;
+            }
+            advance_to_non_boundary();
+            return *this;
+        }
+
+    private:
+        void advance_to_non_boundary()
+        {
+            while (current_ && current_->is_boundary()) {
+                current_ = current_->pair->next;
+                if (current_ == head_) {
+                    current_ = nullptr;
+                    break;
+                }
+            }
+        }
+
+        EdgePtr head_{};
+        EdgePtr current_{};
+    };
+
+    /**
+     * @brief Iterator that lazily flattens all face edges across all faces
+     *
+     * Provides a single flat sequence over all face (non-boundary) edges in
+     * the mesh without allocating a vector. Internally advances through
+     * `faces_` and uses `FaceIterator` within each face.
+     *
+     * @tparam Const If true, is a const iterator
+     */
+    template <bool Const = false>
+    class EdgesIterator
+    {
+    public:
+        /** Difference type */
+        using difference_type = std::ptrdiff_t;
+        /** Value type */
+        using value_type = EdgePtr;
+        /** Pointer type */
+        using pointer = std::conditional_t<Const, value_type const*, value_type*>;
+        /** Reference type */
+        using reference = std::conditional_t<Const, value_type const&, value_type&>;
+        /** Iterator category */
+        using iterator_category = std::input_iterator_tag;
+
+        using FaceVecIter = typename std::vector<FacePtr>::const_iterator;
+
+        /** Construct at position (begin or end depending on faceIt == faceEnd) */
+        EdgesIterator(FaceVecIter faceIt, FaceVecIter faceEnd) : faceIt_{faceIt}, faceEnd_{faceEnd}
+        {
+            if (faceIt_ != faceEnd_) {
+                edgeIt_ = FaceIterator<true>{(*faceIt_)->head, (*faceIt_)->head};
+                advance_if_face_exhausted();
+            }
+        }
+
+        /** Dereference */
+        template <bool C = Const>
+        auto operator*() const -> std::enable_if_t<C, reference>
+        {
+            return *edgeIt_;
+        }
+        template <bool C = Const>
+        auto operator*() -> std::enable_if_t<!C, reference>
+        {
+            return *edgeIt_;
+        }
+
+        /** Equality */
+        auto operator==(const EdgesIterator& other) const -> bool
+        {
+            // Both exhausted (at end)
+            if (faceIt_ == faceEnd_ && other.faceIt_ == other.faceEnd_) {
+                return true;
+            }
+            if (faceIt_ != other.faceIt_) {
+                return false;
+            }
+            return edgeIt_ == other.edgeIt_;
+        }
+        /** Inequality */
+        auto operator!=(const EdgesIterator& other) const -> bool { return !(*this == other); }
+
+        /** Increment */
+        auto operator++() -> EdgesIterator&
+        {
+            ++edgeIt_;
+            advance_if_face_exhausted();
+            return *this;
+        }
+
+    private:
+        void advance_if_face_exhausted()
+        {
+            while (edgeIt_ == FaceIterator<true>() && faceIt_ != faceEnd_) {
+                ++faceIt_;
+                if (faceIt_ != faceEnd_) {
+                    edgeIt_ = FaceIterator<true>{(*faceIt_)->head, (*faceIt_)->head};
+                }
+            }
+        }
+
+        FaceVecIter faceIt_{};
+        FaceVecIter faceEnd_{};
+        FaceIterator<true> edgeIt_{};
+    };
+
 public:
     /** @brief %Vertex type */
     struct Vertex : VertexTraits {
@@ -850,17 +1086,10 @@ public:
          *
          * @throws MeshException If vertex is a boundary vertex.
          */
-        auto wheel() const -> std::vector<EdgePtr>
+        auto wheel() const
         {
-            std::vector<EdgePtr> ret;
-            auto e = edge;
-            do {
-                if (not e->is_boundary()) {
-                    ret.emplace_back(e);
-                }
-                e = e->pair->next;
-            } while (e != edge);
-            return ret;
+            using Iter = WheelIterator<true>;
+            return detail::Range<Iter>{Iter{edge}, Iter{}};
         }
 
         /** @brief Unit vertex normal */
@@ -994,6 +1223,12 @@ public:
         const_iterator cbegin() const { return const_iterator{head, head}; }
         /** @brief Returns the const end iterator */
         const_iterator cend() const { return const_iterator(); }
+        /** @brief Returns an iterable range over the edges of the face (resolves A2) */
+        auto edges() const
+        {
+            using Iter = const_iterator;
+            return detail::Range<Iter>{Iter{head, head}, Iter{}};
+        }
 
         /** @brief Area of the face */
         auto area() const -> T
@@ -1274,21 +1509,17 @@ public:
     }
 
     /** @brief Get the list of vertices in insertion order */
-    auto vertices() const -> std::vector<VertPtr> { return verts_; }
+    auto vertices() const -> const std::vector<VertPtr>& { return verts_; }
 
     /** @brief Get a vertex by index */
     auto vertex(std::size_t idx) const -> VertPtr { return verts_.at(idx); }
 
-    /** @brief Get the list of face edges in insertion order */
-    auto edges() const -> std::vector<EdgePtr>
+    /** @brief Get a lazy range over all face edges in insertion order */
+    auto edges() const
     {
-        std::vector<EdgePtr> edges;
-        for (const auto& f : faces_) {
-            for (const auto& e : *f) {
-                edges.emplace_back(e);
-            }
-        }
-        return edges;
+        using Iter = EdgesIterator<true>;
+        return detail::Range<Iter>{Iter{faces_.cbegin(), faces_.cend()},
+                                   Iter{faces_.cend(), faces_.cend()}};
     }
 
     /** @brief Find an existing edge with the provided end points */
@@ -1360,7 +1591,7 @@ public:
     }
 
     /** @brief Get the list of faces in insertion order */
-    auto faces() const -> std::vector<FacePtr> { return faces_; }
+    auto faces() const -> const std::vector<FacePtr>& { return faces_; }
 
     /** @brief Get a face by index */
     auto face(std::size_t idx) const -> FacePtr { return faces_.at(idx); }
@@ -1453,21 +1684,23 @@ public:
     }
 
     /** @brief Get the list of interior vertices in insertion order */
-    auto vertices_interior() const -> std::vector<VertPtr>
+    auto vertices_interior() const
     {
-        std::vector<VertPtr> ret;
-        std::copy_if(verts_.begin(), verts_.end(), std::back_inserter(ret),
-                     [](auto x) { return not x->is_boundary(); });
-        return ret;
+        auto pred = [](const VertPtr& v) { return not v->is_boundary(); };
+        using BaseIter = typename std::vector<VertPtr>::const_iterator;
+        using Iter = detail::FilteringIterator<BaseIter, decltype(pred)>;
+        return detail::Range<Iter>{Iter{verts_.cbegin(), verts_.cend(), pred},
+                                   Iter{verts_.cend(), verts_.cend(), pred}};
     }
 
-    /** @brief Get the list of boundary vertices in insertion order */
-    auto vertices_boundary() const -> std::vector<VertPtr>
+    /** @brief Get a lazy range over boundary vertices in insertion order */
+    auto vertices_boundary() const
     {
-        std::vector<VertPtr> ret;
-        std::copy_if(verts_.begin(), verts_.end(), std::back_inserter(ret),
-                     [](auto x) { return x->is_boundary(); });
-        return ret;
+        auto pred = [](const VertPtr& v) { return v->is_boundary(); };
+        using BaseIter = typename std::vector<VertPtr>::const_iterator;
+        using Iter = detail::FilteringIterator<BaseIter, decltype(pred)>;
+        return detail::Range<Iter>{Iter{verts_.cbegin(), verts_.cend(), pred},
+                                   Iter{verts_.cend(), verts_.cend(), pred}};
     }
 
     /** @brief Get the number of vertices */
@@ -2727,7 +2960,7 @@ public:
 
         // Pinned vertex selection
         // Get the end points of a boundary edge
-        auto p0 = mesh->vertices_boundary()[0];
+        auto p0 = mesh->vertices_boundary().front();
         auto e = p0->edge;
         do {
             if (e->pair->is_boundary()) {

--- a/single_include/OpenABF/OpenABF.hpp
+++ b/single_include/OpenABF/OpenABF.hpp
@@ -1223,7 +1223,7 @@ public:
         const_iterator cbegin() const { return const_iterator{head, head}; }
         /** @brief Returns the const end iterator */
         const_iterator cend() const { return const_iterator(); }
-        /** @brief Returns an iterable range over the edges of the face (resolves A2) */
+        /** @brief Returns an iterable range over the edges of the face */
         auto edges() const
         {
             using Iter = const_iterator;

--- a/tests/src/TestHalfEdgeMesh.cpp
+++ b/tests/src/TestHalfEdgeMesh.cpp
@@ -365,6 +365,78 @@ TEST(HalfEdgeMesh, FaceEdges)
     }
 }
 
+TEST(HalfEdgeMesh, IterateEdgesCount)
+{
+    // edges() must yield exactly 3 * num_faces() half-edges
+    const auto mesh = ConstructPyramid<MeshType>();
+    std::size_t count{0};
+    for (const auto& e : mesh->edges()) {
+        (void)e;
+        ++count;
+    }
+    EXPECT_EQ(count, 3 * mesh->num_faces());
+}
+
+TEST(HalfEdgeMesh, IterateWheelBoundaryVertex)
+{
+    // Boundary vertices still participate in faces — wheel must work and terminate
+    const auto mesh = ConstructPyramid<MeshType>();
+    const auto v = mesh->vertex(0);
+    EXPECT_TRUE(v->is_boundary());
+
+    std::size_t count{0};
+    for (const auto& e : v->wheel()) {
+        EXPECT_EQ(e->vertex, v);
+        ++count;
+    }
+    EXPECT_EQ(count, 2u);  // vertex 0 is in exactly 2 faces in the pyramid
+}
+
+TEST(HalfEdgeMesh, IterateWheelReIterable)
+{
+    // Iterating a Range twice must yield identical results
+    const auto mesh = ConstructPyramid<MeshType>();
+    const auto apex = mesh->vertex(3);
+
+    auto wheel = apex->wheel();
+    std::vector<std::size_t> first, second;
+    for (const auto& e : wheel) {
+        first.push_back(e->idxI.value());
+    }
+    for (const auto& e : wheel) {
+        second.push_back(e->idxI.value());
+    }
+    EXPECT_EQ(first, second);
+    EXPECT_EQ(first.size(), 3u);
+}
+
+TEST(HalfEdgeMesh, IterateNoInteriorVertices)
+{
+    // A single triangle has no interior vertices
+    const auto mesh = MeshType::New();
+    mesh->insert_vertex(0, 0, 0);
+    mesh->insert_vertex(1, 0, 0);
+    mesh->insert_vertex(0, 1, 0);
+    mesh->insert_face(0, 1, 2);
+
+    EXPECT_TRUE(mesh->vertices_interior().empty());
+    EXPECT_EQ(mesh->num_vertices_interior(), 0u);
+    EXPECT_FALSE(mesh->vertices_boundary().empty());
+}
+
+TEST(HalfEdgeMesh, RangeFrontEmpty)
+{
+    // Range::front() and Range::empty() must behave correctly
+    const auto mesh = ConstructPyramid<MeshType>();
+
+    EXPECT_FALSE(mesh->edges().empty());
+    EXPECT_NE(mesh->edges().front(), nullptr);
+    EXPECT_FALSE(mesh->vertices_boundary().empty());
+    EXPECT_NE(mesh->vertices_boundary().front(), nullptr);
+    EXPECT_FALSE(mesh->vertices_interior().empty());
+    EXPECT_NE(mesh->vertices_interior().front(), nullptr);
+}
+
 TEST(HalfEdgeMesh, Clone)
 {
     const auto mesh = ConstructPyramid<MeshType>();

--- a/tests/src/TestHalfEdgeMesh.cpp
+++ b/tests/src/TestHalfEdgeMesh.cpp
@@ -275,6 +275,96 @@ TEST(HalfEdgeMesh, FindPath_Disconnected)
     EXPECT_TRUE(path.empty());
 }
 
+TEST(HalfEdgeMesh, IterateVertices)
+{
+    const auto mesh = ConstructPyramid<MeshType>();
+    std::size_t count{0};
+    for (const auto& v : mesh->vertices()) {
+        EXPECT_EQ(v, mesh->vertex(v->idx));
+        ++count;
+    }
+    EXPECT_EQ(count, mesh->num_vertices());
+}
+
+TEST(HalfEdgeMesh, IterateFaces)
+{
+    const auto mesh = ConstructPyramid<MeshType>();
+    std::size_t count{0};
+    for (const auto& f : mesh->faces()) {
+        EXPECT_EQ(f, mesh->face(f->idx));
+        ++count;
+    }
+    EXPECT_EQ(count, mesh->num_faces());
+}
+
+TEST(HalfEdgeMesh, IterateEdges)
+{
+    const auto mesh = ConstructPyramid<MeshType>();
+    // Collect via mesh->edges()
+    std::vector<std::size_t> edgeIdxs;
+    for (const auto& e : mesh->edges()) {
+        edgeIdxs.push_back(e->idxI.value());
+    }
+    // Collect via face-by-face iteration
+    std::vector<std::size_t> expected;
+    for (const auto& f : mesh->faces()) {
+        for (const auto& e : *f) {
+            expected.push_back(e->idxI.value());
+        }
+    }
+    EXPECT_EQ(edgeIdxs, expected);
+}
+
+TEST(HalfEdgeMesh, IterateInteriorBoundaryPartition)
+{
+    const auto mesh = ConstructPyramid<MeshType>();
+    std::size_t intCount{0}, bndCount{0};
+    for (const auto& v : mesh->vertices_interior()) {
+        EXPECT_TRUE(v->is_interior());
+        ++intCount;
+    }
+    for (const auto& v : mesh->vertices_boundary()) {
+        EXPECT_TRUE(v->is_boundary());
+        ++bndCount;
+    }
+    EXPECT_EQ(intCount + bndCount, mesh->num_vertices());
+    EXPECT_EQ(intCount, mesh->num_vertices_interior());
+}
+
+TEST(HalfEdgeMesh, IterateWheel)
+{
+    // Pyramid apex (vertex 3) is interior — wheel should yield all its face edges
+    const auto mesh = ConstructPyramid<MeshType>();
+    const auto apex = mesh->vertex(3);
+    EXPECT_TRUE(apex->is_interior());
+
+    std::vector<std::size_t> wheelIdxs;
+    for (const auto& e : apex->wheel()) {
+        wheelIdxs.push_back(e->idxI.value());
+    }
+    EXPECT_EQ(wheelIdxs.size(), 3u);  // pyramid apex touches 3 faces
+    // All edges must belong to this vertex
+    for (const auto& e : apex->wheel()) {
+        EXPECT_EQ(e->vertex, apex);
+    }
+}
+
+TEST(HalfEdgeMesh, FaceEdges)
+{
+    const auto mesh = ConstructPyramid<MeshType>();
+    for (const auto& f : mesh->faces()) {
+        // face->edges() and *face should yield the same edge sequence
+        std::vector<std::size_t> viaEdges, viaStar;
+        for (const auto& e : f->edges()) {
+            viaEdges.push_back(e->idx);
+        }
+        for (const auto& e : *f) {
+            viaStar.push_back(e->idx);
+        }
+        EXPECT_EQ(viaEdges, viaStar);
+    }
+}
+
 TEST(HalfEdgeMesh, Clone)
 {
     const auto mesh = ConstructPyramid<MeshType>();


### PR DESCRIPTION
## Summary

- **P1**: Eliminates hot-path heap allocations in the ABF/ABFPlusPlus solver loops (~10+ vector allocations per solver iteration on a mesh with F faces and V_int interior vertices)
- **A2**: Adds `face->edges()` named iterable accessor, resolving the awkward `*face` dereference pattern
- **P3**: `InitializeAnglesAndWeights` already calls `v->wheel()` exactly once and stores the result; with P1's re-iterable `Range<WheelIterator>`, no allocation or redundancy remains

### Changes

| Method | Before | After |
|--------|--------|-------|
| `vertices()` | `std::vector<VertPtr>` (copy) | `const std::vector<VertPtr>&` |
| `faces()` | `std::vector<FacePtr>` (copy) | `const std::vector<FacePtr>&` |
| `edges()` | `std::vector<EdgePtr>` (built per call) | `Range<EdgesIterator>` (lazy) |
| `vertices_interior()` | `std::vector<VertPtr>` (filtered copy) | `Range<FilteringIterator<...>>` |
| `vertices_boundary()` | `std::vector<VertPtr>` (filtered copy) | `Range<FilteringIterator<...>>` |
| `Vertex::wheel()` | `std::vector<EdgePtr>` (built per call) | `Range<WheelIterator>` (lazy) |
| `Face::edges()` | *(new)* | `Range<FaceIterator>` |

### New types (all in `HalfEdgeMesh.hpp`)

- `detail::Range<Iter>` — lightweight begin/end wrapper supporting range-for, `.empty()`, `.front()`
- `detail::FilteringIterator<Iter, Pred>` — input iterator skipping non-matching elements
- `WheelIterator<Const>` — linked-list walk around a vertex (`edge->pair->next` chain), skipping boundary edges
- `EdgesIterator<Const>` — lazily flattens all face edges across all faces

All existing call sites are syntactically unchanged (range-for, `.size()`, `.num_*()`) except `AngleBasedLSCM::Compute` which changes `vertices_boundary()[0]` → `vertices_boundary().front()`.

Kept as vector-returning (not hot path): `outgoing_edges()`, `incoming_edges()`, `boundaries()`, `connected_components()`.

## Test plan

- [x] 11 regression tests in `TestHalfEdgeMesh.cpp`: `IterateVertices`, `IterateFaces`, `IterateEdges`, `IterateEdgesCount`, `IterateInteriorBoundaryPartition`, `IterateWheel`, `IterateWheelBoundaryVertex`, `IterateWheelReIterable`, `IterateNoInteriorVertices`, `RangeFrontEmpty`, `FaceEdges`
- [x] All existing tests pass
- [x] All examples compile
- [x] `git clang-format` applied
- [x] Single-header amalgamation updated

Closes #4, Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)