### PR TITLE
refactor: add [[nodiscard]] to gradient() and replace vIdx2vIntIdx map with vector (A4, P2)

### DIFF
--- a/include/OpenABF/ABF.hpp
+++ b/include/OpenABF/ABF.hpp
@@ -1,6 +1,9 @@
 #pragma once
 
+#include <cassert>
 #include <cmath>
+#include <limits>
+#include <vector>
 
 #include <Eigen/SparseLU>
 
@@ -239,7 +242,7 @@ public:
      *
      * **Note:** Result is only valid after running compute().
      */
-    auto gradient() const -> T { return grad_; }
+    [[nodiscard]] auto gradient() const -> T { return grad_; }
 
     /**
      * @brief Get the number of iterations of the last computation
@@ -273,6 +276,17 @@ public:
         }
         auto gradDelta = INF<T>;
         iters = 0;
+
+        // vertex idx -> interior vertex idx lookup (pre-built once, O(1) access)
+        auto vCnt = mesh->num_vertices();
+        std::vector<std::size_t> vIdx2vIntIdx(vCnt, std::numeric_limits<std::size_t>::max());
+        {
+            std::size_t newIdx{0};
+            for (const auto& v : mesh->vertices_interior()) {
+                vIdx2vIntIdx[v->idx] = newIdx++;
+            }
+        }
+
         while (gradient > 0.001 and gradDelta > 0.001 and iters < maxIters) {
             if (std::isnan(gradient) or std::isinf(gradient)) {
                 throw MeshException("Mesh gradient cannot be computed");
@@ -283,7 +297,6 @@ public:
             using DenseVector = Eigen::Matrix<T, Eigen::Dynamic, 1>;
 
             // Helpful parameters
-            auto vCnt = mesh->num_vertices();
             auto vIntCnt = mesh->num_vertices_interior();
             auto edgeCnt = mesh->num_edges();
             auto faceCnt = mesh->num_faces();
@@ -312,13 +325,6 @@ public:
             SparseMatrix b(edgeCnt + faceCnt + 2 * vIntCnt, 1);
             b.reserve(triplets.size());
             b.setFromTriplets(triplets.begin(), triplets.end());
-
-            // vertex idx -> interior vertex idx permutation
-            std::map<std::size_t, std::size_t> vIdx2vIntIdx;
-            std::size_t newIdx{0};
-            for (const auto& v : mesh->vertices_interior()) {
-                vIdx2vIntIdx[v->idx] = newIdx++;
-            }
 
             ///// LHS /////
             // Lambda = diag(2/w)
@@ -396,7 +402,8 @@ public:
             }
             auto base = edgeCnt + faceCnt;
             for (auto& v : mesh->vertices_interior()) {
-                auto intIdx = vIdx2vIntIdx.at(v->idx);
+                auto intIdx = vIdx2vIntIdx[v->idx];
+                assert(intIdx != std::numeric_limits<std::size_t>::max());
                 v->lambda_plan += delta(base + intIdx, 0);
                 v->lambda_len += delta(base + vIntCnt + intIdx, 0);
             }

--- a/include/OpenABF/ABFPlusPlus.hpp
+++ b/include/OpenABF/ABFPlusPlus.hpp
@@ -1,6 +1,9 @@
 #pragma once
 
+#include <cassert>
 #include <cmath>
+#include <limits>
+#include <vector>
 
 #include <Eigen/SparseLU>
 
@@ -52,7 +55,7 @@ public:
      *
      * **Note:** Result is only valid after running compute().
      */
-    auto gradient() const -> T { return grad_; }
+    [[nodiscard]] auto gradient() const -> T { return grad_; }
 
     /**
      * @brief Get the number of iterations of the last computation
@@ -86,6 +89,17 @@ public:
         }
         auto gradDelta = INF<T>;
         iters = 0;
+
+        // vertex idx -> interior vertex idx lookup (pre-built once, O(1) access)
+        std::vector<std::size_t> vIdx2vIntIdx(mesh->num_vertices(),
+                                              std::numeric_limits<std::size_t>::max());
+        {
+            std::size_t newIdx{0};
+            for (const auto& v : mesh->vertices_interior()) {
+                vIdx2vIntIdx[v->idx] = newIdx++;
+            }
+        }
+
         while (gradient > 0.001 and gradDelta > 0.001 and iters < maxIters) {
             if (std::isnan(gradient) or std::isinf(gradient)) {
                 throw MeshException("Mesh gradient cannot be computed");
@@ -128,13 +142,6 @@ public:
             SparseMatrix b2(faceCnt + 2 * vIntCnt, 1);
             b2.reserve(triplets.size());
             b2.setFromTriplets(triplets.begin(), triplets.end());
-
-            // vertex idx -> interior vertex idx permutation
-            std::map<std::size_t, std::size_t> vIdx2vIntIdx;
-            std::size_t newIdx{0};
-            for (const auto& v : mesh->vertices_interior()) {
-                vIdx2vIntIdx[v->idx] = newIdx++;
-            }
 
             // Compute J1 + J2
             triplets.clear();
@@ -222,7 +229,8 @@ public:
                 f->lambda_tri += deltaLambda(f->idx, 0);
             }
             for (auto& v : mesh->vertices_interior()) {
-                auto intIdx = vIdx2vIntIdx.at(v->idx);
+                auto intIdx = vIdx2vIntIdx[v->idx];
+                assert(intIdx != std::numeric_limits<std::size_t>::max());
                 v->lambda_plan += deltaLambda(faceCnt + intIdx, 0);
                 v->lambda_len += deltaLambda(faceCnt + vIntCnt + intIdx, 0);
             }

--- a/single_include/OpenABF/OpenABF.hpp
+++ b/single_include/OpenABF/OpenABF.hpp
@@ -2137,7 +2137,10 @@ private:
 // #include "OpenABF/ABF.hpp"
 
 
+#include <cassert>
 #include <cmath>
+#include <limits>
+#include <vector>
 
 #include <Eigen/SparseLU>
 
@@ -2379,7 +2382,7 @@ public:
      *
      * **Note:** Result is only valid after running compute().
      */
-    auto gradient() const -> T { return grad_; }
+    [[nodiscard]] auto gradient() const -> T { return grad_; }
 
     /**
      * @brief Get the number of iterations of the last computation
@@ -2413,6 +2416,17 @@ public:
         }
         auto gradDelta = INF<T>;
         iters = 0;
+
+        // vertex idx -> interior vertex idx lookup (pre-built once, O(1) access)
+        auto vCnt = mesh->num_vertices();
+        std::vector<std::size_t> vIdx2vIntIdx(vCnt, std::numeric_limits<std::size_t>::max());
+        {
+            std::size_t newIdx{0};
+            for (const auto& v : mesh->vertices_interior()) {
+                vIdx2vIntIdx[v->idx] = newIdx++;
+            }
+        }
+
         while (gradient > 0.001 and gradDelta > 0.001 and iters < maxIters) {
             if (std::isnan(gradient) or std::isinf(gradient)) {
                 throw MeshException("Mesh gradient cannot be computed");
@@ -2423,7 +2437,6 @@ public:
             using DenseVector = Eigen::Matrix<T, Eigen::Dynamic, 1>;
 
             // Helpful parameters
-            auto vCnt = mesh->num_vertices();
             auto vIntCnt = mesh->num_vertices_interior();
             auto edgeCnt = mesh->num_edges();
             auto faceCnt = mesh->num_faces();
@@ -2452,13 +2465,6 @@ public:
             SparseMatrix b(edgeCnt + faceCnt + 2 * vIntCnt, 1);
             b.reserve(triplets.size());
             b.setFromTriplets(triplets.begin(), triplets.end());
-
-            // vertex idx -> interior vertex idx permutation
-            std::map<std::size_t, std::size_t> vIdx2vIntIdx;
-            std::size_t newIdx{0};
-            for (const auto& v : mesh->vertices_interior()) {
-                vIdx2vIntIdx[v->idx] = newIdx++;
-            }
 
             ///// LHS /////
             // Lambda = diag(2/w)
@@ -2536,7 +2542,8 @@ public:
             }
             auto base = edgeCnt + faceCnt;
             for (auto& v : mesh->vertices_interior()) {
-                auto intIdx = vIdx2vIntIdx.at(v->idx);
+                auto intIdx = vIdx2vIntIdx[v->idx];
+                assert(intIdx != std::numeric_limits<std::size_t>::max());
                 v->lambda_plan += delta(base + intIdx, 0);
                 v->lambda_len += delta(base + vIntCnt + intIdx, 0);
             }
@@ -2570,7 +2577,10 @@ protected:
 // #include "OpenABF/ABFPlusPlus.hpp"
 
 
+#include <cassert>
 #include <cmath>
+#include <limits>
+#include <vector>
 
 #include <Eigen/SparseLU>
 
@@ -2626,7 +2636,7 @@ public:
      *
      * **Note:** Result is only valid after running compute().
      */
-    auto gradient() const -> T { return grad_; }
+    [[nodiscard]] auto gradient() const -> T { return grad_; }
 
     /**
      * @brief Get the number of iterations of the last computation
@@ -2660,6 +2670,17 @@ public:
         }
         auto gradDelta = INF<T>;
         iters = 0;
+
+        // vertex idx -> interior vertex idx lookup (pre-built once, O(1) access)
+        std::vector<std::size_t> vIdx2vIntIdx(mesh->num_vertices(),
+                                              std::numeric_limits<std::size_t>::max());
+        {
+            std::size_t newIdx{0};
+            for (const auto& v : mesh->vertices_interior()) {
+                vIdx2vIntIdx[v->idx] = newIdx++;
+            }
+        }
+
         while (gradient > 0.001 and gradDelta > 0.001 and iters < maxIters) {
             if (std::isnan(gradient) or std::isinf(gradient)) {
                 throw MeshException("Mesh gradient cannot be computed");
@@ -2702,13 +2723,6 @@ public:
             SparseMatrix b2(faceCnt + 2 * vIntCnt, 1);
             b2.reserve(triplets.size());
             b2.setFromTriplets(triplets.begin(), triplets.end());
-
-            // vertex idx -> interior vertex idx permutation
-            std::map<std::size_t, std::size_t> vIdx2vIntIdx;
-            std::size_t newIdx{0};
-            for (const auto& v : mesh->vertices_interior()) {
-                vIdx2vIntIdx[v->idx] = newIdx++;
-            }
 
             // Compute J1 + J2
             triplets.clear();
@@ -2796,7 +2810,8 @@ public:
                 f->lambda_tri += deltaLambda(f->idx, 0);
             }
             for (auto& v : mesh->vertices_interior()) {
-                auto intIdx = vIdx2vIntIdx.at(v->idx);
+                auto intIdx = vIdx2vIntIdx[v->idx];
+                assert(intIdx != std::numeric_limits<std::size_t>::max());
                 v->lambda_plan += deltaLambda(faceCnt + intIdx, 0);
                 v->lambda_len += deltaLambda(faceCnt + vIntCnt + intIdx, 0);
             }


### PR DESCRIPTION
## Summary

- **A4**: `gradient()` in both `ABF` and `ABFPlusPlus` is now `[[nodiscard]]`, consistent with `iterations()` which was already annotated
- **P2**: `vIdx2vIntIdx` is pre-built once before the solver loop as a flat `std::vector<std::size_t>` indexed directly by vertex idx (sentinel `std::numeric_limits<std::size_t>::max()`), replacing the `std::map` that was rebuilt on every iteration. Lookup is now O(1) vs O(log n). An `assert` guards against accidental access with a non-interior vertex idx in debug builds. Adds explicit `<cassert>`, `<limits>`, and `<vector>` includes to both files.

## Test plan

- [x] All existing tests pass (`ctest`)
- [x] All examples compile
- [x] `git clang-format` applied
- [x] Single-header amalgamation updated

Closes #17, Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)