### PR TITLE
docs: document insert_face boundary update behavior (A3)

### DIFF
--- a/include/OpenABF/HalfEdgeMesh.hpp
+++ b/include/OpenABF/HalfEdgeMesh.hpp
@@ -950,6 +950,10 @@ public:
      *
      * Accepts an iterable supporting range-based for loops.
      *
+     * @note This function does **not** update the mesh boundary connections.
+     * Call update_boundary() after all faces have been inserted, or use
+     * insert_faces() to insert faces and update the boundary in one step.
+     *
      * @param vector List of vertex indices
      * @throws std::out_of_range If one of the vertex indices is out of bounds.
      * @throws MeshException (1) If one of provided edges is already paired.
@@ -966,9 +970,11 @@ public:
     /**
      * @brief Insert a new face from an ordered list of Vertex indices
      *
-     * This function inserts a face but **does not** update the mesh's boundary
-     * connections. Make sure to call update_boundary() after all faces have
-     * been inserted or use insert_faces() to insert and update in one step.
+     * Accepts vertex indices as individual variadic arguments.
+     *
+     * @note This function does **not** update the mesh boundary connections.
+     * Call update_boundary() after all faces have been inserted, or use
+     * insert_faces() to insert faces and update the boundary in one step.
      *
      * @throws std::out_of_range If one of the vertex indices is out of bounds.
      * @throws MeshException If one of provided edges is already paired. This

--- a/single_include/OpenABF/OpenABF.hpp
+++ b/single_include/OpenABF/OpenABF.hpp
@@ -1394,6 +1394,10 @@ public:
      *
      * Accepts an iterable supporting range-based for loops.
      *
+     * @note This function does **not** update the mesh boundary connections.
+     * Call update_boundary() after all faces have been inserted, or use
+     * insert_faces() to insert faces and update the boundary in one step.
+     *
      * @param vector List of vertex indices
      * @throws std::out_of_range If one of the vertex indices is out of bounds.
      * @throws MeshException (1) If one of provided edges is already paired.
@@ -1410,9 +1414,11 @@ public:
     /**
      * @brief Insert a new face from an ordered list of Vertex indices
      *
-     * This function inserts a face but **does not** update the mesh's boundary
-     * connections. Make sure to call update_boundary() after all faces have
-     * been inserted or use insert_faces() to insert and update in one step.
+     * Accepts vertex indices as individual variadic arguments.
+     *
+     * @note This function does **not** update the mesh boundary connections.
+     * Call update_boundary() after all faces have been inserted, or use
+     * insert_faces() to insert faces and update the boundary in one step.
      *
      * @throws std::out_of_range If one of the vertex indices is out of bounds.
      * @throws MeshException If one of provided edges is already paired. This


### PR DESCRIPTION
## Summary

Both `insert_face` overloads (vector form and variadic form) now carry a consistent `@note` in their Doxygen comments explaining that boundary connections are **not** updated, and that callers must follow with `update_boundary()` — or use `insert_faces()` which handles this automatically.

Previously only the variadic form had this note (worded as inline prose rather than a `@note`). The vector form had no mention of it at all.

No behavioral changes.

## Test plan

- [x] All existing tests pass (`ctest`)
- [x] `git clang-format` applied
- [x] Single-header amalgamation updated

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)