### PR TITLE
feat: add configurable gradient threshold to ABF and ABFPlusPlus (A1)

### DIFF
--- a/include/OpenABF/ABF.hpp
+++ b/include/OpenABF/ABF.hpp
@@ -237,6 +237,9 @@ public:
     /** @brief Set the maximum number of iterations */
     void setMaxIterations(const std::size_t it) { maxIters_ = it; }
 
+    /** @brief Set the gradient convergence threshold */
+    void setGradientThreshold(T t) { gradThreshold_ = t; }
+
     /**
      * @brief Get the mesh gradient
      *
@@ -252,7 +255,10 @@ public:
     [[nodiscard]] auto iterations() const -> std::size_t { return iters_; }
 
     /** @copydoc ABF::Compute */
-    void compute(typename Mesh::Pointer& mesh) { Compute(mesh, iters_, grad_, maxIters_); }
+    void compute(typename Mesh::Pointer& mesh)
+    {
+        Compute(mesh, iters_, grad_, maxIters_, gradThreshold_);
+    }
 
     /**
      * @brief Compute parameterized interior angles
@@ -262,7 +268,7 @@ public:
      * @throws MeshException If mesh gradient cannot be calculated.
      */
     static void Compute(typename Mesh::Pointer& mesh, std::size_t& iters, T& gradient,
-                        const std::size_t maxIters = 10)
+                        const std::size_t maxIters = 10, T gradThreshold = T(0.001))
     {
         using namespace detail::ABF;
 
@@ -287,7 +293,7 @@ public:
             }
         }
 
-        while (gradient > 0.001 and gradDelta > 0.001 and iters < maxIters) {
+        while (gradient > gradThreshold and gradDelta > gradThreshold and iters < maxIters) {
             if (std::isnan(gradient) or std::isinf(gradient)) {
                 throw MeshException("Mesh gradient cannot be computed");
             }
@@ -431,6 +437,8 @@ protected:
     std::size_t iters_{0};
     /** Max iterations */
     std::size_t maxIters_{10};
+    /** Gradient convergence threshold */
+    T gradThreshold_{0.001};
 };
 
 }  // namespace OpenABF

--- a/include/OpenABF/ABFPlusPlus.hpp
+++ b/include/OpenABF/ABFPlusPlus.hpp
@@ -50,6 +50,9 @@ public:
     /** @brief Set the maximum number of iterations */
     void setMaxIterations(std::size_t it) { maxIters_ = it; }
 
+    /** @brief Set the gradient convergence threshold */
+    void setGradientThreshold(T t) { gradThreshold_ = t; }
+
     /**
      * @brief Get the mesh gradient
      *
@@ -65,7 +68,10 @@ public:
     [[nodiscard]] auto iterations() const -> std::size_t { return iters_; }
 
     /** @copydoc ABFPlusPlus::Compute */
-    void compute(typename Mesh::Pointer& mesh) { Compute(mesh, iters_, grad_, maxIters_); }
+    void compute(typename Mesh::Pointer& mesh)
+    {
+        Compute(mesh, iters_, grad_, maxIters_, gradThreshold_);
+    }
 
     /**
      * @brief Compute parameterized interior angles
@@ -75,7 +81,7 @@ public:
      * @throws MeshException If mesh gradient cannot be calculated.
      */
     static void Compute(typename Mesh::Pointer& mesh, std::size_t& iters, T& gradient,
-                        const std::size_t maxIters = 10)
+                        const std::size_t maxIters = 10, T gradThreshold = T(0.001))
     {
         using namespace detail::ABF;
 
@@ -100,7 +106,7 @@ public:
             }
         }
 
-        while (gradient > 0.001 and gradDelta > 0.001 and iters < maxIters) {
+        while (gradient > gradThreshold and gradDelta > gradThreshold and iters < maxIters) {
             if (std::isnan(gradient) or std::isinf(gradient)) {
                 throw MeshException("Mesh gradient cannot be computed");
             }
@@ -268,6 +274,8 @@ private:
     std::size_t iters_{0};
     /** Max iterations */
     std::size_t maxIters_{10};
+    /** Gradient convergence threshold */
+    T gradThreshold_{0.001};
 };
 
 }  // namespace OpenABF

--- a/single_include/OpenABF/OpenABF.hpp
+++ b/single_include/OpenABF/OpenABF.hpp
@@ -2383,6 +2383,9 @@ public:
     /** @brief Set the maximum number of iterations */
     void setMaxIterations(const std::size_t it) { maxIters_ = it; }
 
+    /** @brief Set the gradient convergence threshold */
+    void setGradientThreshold(T t) { gradThreshold_ = t; }
+
     /**
      * @brief Get the mesh gradient
      *
@@ -2398,7 +2401,10 @@ public:
     [[nodiscard]] auto iterations() const -> std::size_t { return iters_; }
 
     /** @copydoc ABF::Compute */
-    void compute(typename Mesh::Pointer& mesh) { Compute(mesh, iters_, grad_, maxIters_); }
+    void compute(typename Mesh::Pointer& mesh)
+    {
+        Compute(mesh, iters_, grad_, maxIters_, gradThreshold_);
+    }
 
     /**
      * @brief Compute parameterized interior angles
@@ -2408,7 +2414,7 @@ public:
      * @throws MeshException If mesh gradient cannot be calculated.
      */
     static void Compute(typename Mesh::Pointer& mesh, std::size_t& iters, T& gradient,
-                        const std::size_t maxIters = 10)
+                        const std::size_t maxIters = 10, T gradThreshold = T(0.001))
     {
         using namespace detail::ABF;
 
@@ -2433,7 +2439,7 @@ public:
             }
         }
 
-        while (gradient > 0.001 and gradDelta > 0.001 and iters < maxIters) {
+        while (gradient > gradThreshold and gradDelta > gradThreshold and iters < maxIters) {
             if (std::isnan(gradient) or std::isinf(gradient)) {
                 throw MeshException("Mesh gradient cannot be computed");
             }
@@ -2577,6 +2583,8 @@ protected:
     std::size_t iters_{0};
     /** Max iterations */
     std::size_t maxIters_{10};
+    /** Gradient convergence threshold */
+    T gradThreshold_{0.001};
 };
 
 }  // namespace OpenABF
@@ -2637,6 +2645,9 @@ public:
     /** @brief Set the maximum number of iterations */
     void setMaxIterations(std::size_t it) { maxIters_ = it; }
 
+    /** @brief Set the gradient convergence threshold */
+    void setGradientThreshold(T t) { gradThreshold_ = t; }
+
     /**
      * @brief Get the mesh gradient
      *
@@ -2652,7 +2663,10 @@ public:
     [[nodiscard]] auto iterations() const -> std::size_t { return iters_; }
 
     /** @copydoc ABFPlusPlus::Compute */
-    void compute(typename Mesh::Pointer& mesh) { Compute(mesh, iters_, grad_, maxIters_); }
+    void compute(typename Mesh::Pointer& mesh)
+    {
+        Compute(mesh, iters_, grad_, maxIters_, gradThreshold_);
+    }
 
     /**
      * @brief Compute parameterized interior angles
@@ -2662,7 +2676,7 @@ public:
      * @throws MeshException If mesh gradient cannot be calculated.
      */
     static void Compute(typename Mesh::Pointer& mesh, std::size_t& iters, T& gradient,
-                        const std::size_t maxIters = 10)
+                        const std::size_t maxIters = 10, T gradThreshold = T(0.001))
     {
         using namespace detail::ABF;
 
@@ -2687,7 +2701,7 @@ public:
             }
         }
 
-        while (gradient > 0.001 and gradDelta > 0.001 and iters < maxIters) {
+        while (gradient > gradThreshold and gradDelta > gradThreshold and iters < maxIters) {
             if (std::isnan(gradient) or std::isinf(gradient)) {
                 throw MeshException("Mesh gradient cannot be computed");
             }
@@ -2855,6 +2869,8 @@ private:
     std::size_t iters_{0};
     /** Max iterations */
     std::size_t maxIters_{10};
+    /** Gradient convergence threshold */
+    T gradThreshold_{0.001};
 };
 
 }  // namespace OpenABF

--- a/tests/src/TestParameterization.cpp
+++ b/tests/src/TestParameterization.cpp
@@ -158,3 +158,34 @@ TEST(Parameterizations, ABF_MaxIters)
 
     EXPECT_EQ(abf.iterations(), 1u);
 }
+
+TEST(Parameterizations, ABFPlusPlus_TightThreshold)
+{
+    // Tighter threshold should produce a lower final gradient than the default
+    using ABFType = ABFPlusPlus<float>;
+
+    auto mesh_default = ConstructPyramid<ABFType::Mesh>();
+    ABFType abf_default;
+    abf_default.compute(mesh_default);
+
+    auto mesh_tight = ConstructPyramid<ABFType::Mesh>();
+    ABFType abf_tight;
+    abf_tight.setGradientThreshold(1e-6f);
+    abf_tight.setMaxIterations(100);
+    abf_tight.compute(mesh_tight);
+
+    EXPECT_LE(abf_tight.gradient(), abf_default.gradient());
+}
+
+TEST(Parameterizations, ABFPlusPlus_LooseThreshold)
+{
+    // A threshold larger than the initial gradient causes zero solver iterations
+    using ABFType = ABFPlusPlus<float>;
+
+    auto mesh = ConstructPyramid<ABFType::Mesh>();
+    ABFType abf;
+    abf.setGradientThreshold(1e6f);
+    abf.compute(mesh);
+
+    EXPECT_EQ(abf.iterations(), 0u);
+}


### PR DESCRIPTION
## Summary
- Adds `setGradientThreshold(T)` method to both `ABF` and `ABFPlusPlus` alongside the existing `setMaxIterations()`
- Adds `gradThreshold` parameter (defaulting to `T(0.001)`) to the full static `Compute()` overload on both classes
- Replaces the hardcoded `0.001` literal in the solver `while` loop with the configurable parameter
- Fully backward-compatible: default value preserves existing behavior

## Test plan
- [x] All existing tests pass unchanged (10/10 parameterization tests pass)
- [x] `ABFPlusPlus_TightThreshold`: tightening threshold to 1e-6 produces a lower final gradient than the default
- [x] `ABFPlusPlus_LooseThreshold`: threshold of 1e6 (above initial gradient) causes zero solver iterations

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)