### PR TITLE
feat: add explicit pin selection to AngleBasedLSCM (A5)

### DIFF
--- a/include/OpenABF/AngleBasedLSCM.hpp
+++ b/include/OpenABF/AngleBasedLSCM.hpp
@@ -2,7 +2,9 @@
 
 #include <cmath>
 #include <map>
+#include <optional>
 #include <type_traits>
+#include <utility>
 
 #include <Eigen/IterativeLinearSolvers>
 #include <Eigen/SparseLU>
@@ -99,11 +101,27 @@ public:
     /** @brief Mesh type alias */
     using Mesh = MeshType;
 
-    /** @copydoc AngleBasedLSCM::Compute */
-    void compute(typename Mesh::Pointer& mesh) const { Compute(mesh); }
+    /** @brief Set the pinned vertex indices used by compute() */
+    void setPinnedVertices(std::size_t pin0Idx, std::size_t pin1Idx)
+    {
+        pinnedVertices_ = {pin0Idx, pin1Idx};
+    }
+
+    /** @copydoc AngleBasedLSCM::Compute() */
+    void compute(typename Mesh::Pointer& mesh) const
+    {
+        if (pinnedVertices_) {
+            Compute(mesh, pinnedVertices_->first, pinnedVertices_->second);
+        } else {
+            Compute(mesh);
+        }
+    }
 
     /**
-     * @brief Compute the parameterized mesh
+     * @brief Compute the parameterized mesh using automatic pin selection
+     *
+     * Selects the first boundary vertex and its boundary-edge neighbor as
+     * pinned vertices.
      *
      * @throws MeshException If pinned vertex is not on boundary.
      * @throws SolverException If matrix cannot be decomposed or if solver fails
@@ -111,12 +129,7 @@ public:
      */
     static void Compute(typename Mesh::Pointer& mesh)
     {
-        using Triplet = Eigen::Triplet<T>;
-        using SparseMatrix = Eigen::SparseMatrix<T>;
-        using DenseMatrix = Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>;
-
-        // Pinned vertex selection
-        // Get the end points of a boundary edge
+        // Pinned vertex selection: first boundary vertex + boundary-edge neighbor
         auto p0 = mesh->vertices_boundary().front();
         auto e = p0->edge;
         do {
@@ -129,6 +142,35 @@ public:
             throw MeshException("Pinned vertex not on boundary");
         }
         auto p1 = e->next->vertex;
+        ComputeImpl(mesh, p0, p1);
+    }
+
+    /**
+     * @brief Compute the parameterized mesh with explicit pinned vertex indices
+     *
+     * @param pin0Idx Index of the first pinned vertex (placed at the UV origin)
+     * @param pin1Idx Index of the second pinned vertex (placed on the nearest axis)
+     * @throws SolverException If matrix cannot be decomposed or if solver fails
+     * to find a solution.
+     */
+    static void Compute(typename Mesh::Pointer& mesh, std::size_t pin0Idx, std::size_t pin1Idx)
+    {
+        ComputeImpl(mesh, mesh->vertex(pin0Idx), mesh->vertex(pin1Idx));
+    }
+
+private:
+    /** Optional explicit pin pair set via setPinnedVertices() */
+    std::optional<std::pair<std::size_t, std::size_t>> pinnedVertices_;
+
+    /**
+     * @brief Core solver: place p0/p1 on the UV axes then solve for free vertices
+     */
+    static void ComputeImpl(typename Mesh::Pointer& mesh, const typename Mesh::VertPtr& p0,
+                            const typename Mesh::VertPtr& p1)
+    {
+        using Triplet = Eigen::Triplet<T>;
+        using SparseMatrix = Eigen::SparseMatrix<T>;
+        using DenseMatrix = Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>;
 
         // Map selected edge to closest XY axis
         // Use sign to select direction

--- a/single_include/OpenABF/OpenABF.hpp
+++ b/single_include/OpenABF/OpenABF.hpp
@@ -2879,7 +2879,9 @@ private:
 
 #include <cmath>
 #include <map>
+#include <optional>
 #include <type_traits>
+#include <utility>
 
 #include <Eigen/IterativeLinearSolvers>
 #include <Eigen/SparseLU>
@@ -2979,11 +2981,27 @@ public:
     /** @brief Mesh type alias */
     using Mesh = MeshType;
 
-    /** @copydoc AngleBasedLSCM::Compute */
-    void compute(typename Mesh::Pointer& mesh) const { Compute(mesh); }
+    /** @brief Set the pinned vertex indices used by compute() */
+    void setPinnedVertices(std::size_t pin0Idx, std::size_t pin1Idx)
+    {
+        pinnedVertices_ = {pin0Idx, pin1Idx};
+    }
+
+    /** @copydoc AngleBasedLSCM::Compute() */
+    void compute(typename Mesh::Pointer& mesh) const
+    {
+        if (pinnedVertices_) {
+            Compute(mesh, pinnedVertices_->first, pinnedVertices_->second);
+        } else {
+            Compute(mesh);
+        }
+    }
 
     /**
-     * @brief Compute the parameterized mesh
+     * @brief Compute the parameterized mesh using automatic pin selection
+     *
+     * Selects the first boundary vertex and its boundary-edge neighbor as
+     * pinned vertices.
      *
      * @throws MeshException If pinned vertex is not on boundary.
      * @throws SolverException If matrix cannot be decomposed or if solver fails
@@ -2991,12 +3009,7 @@ public:
      */
     static void Compute(typename Mesh::Pointer& mesh)
     {
-        using Triplet = Eigen::Triplet<T>;
-        using SparseMatrix = Eigen::SparseMatrix<T>;
-        using DenseMatrix = Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>;
-
-        // Pinned vertex selection
-        // Get the end points of a boundary edge
+        // Pinned vertex selection: first boundary vertex + boundary-edge neighbor
         auto p0 = mesh->vertices_boundary().front();
         auto e = p0->edge;
         do {
@@ -3009,6 +3022,35 @@ public:
             throw MeshException("Pinned vertex not on boundary");
         }
         auto p1 = e->next->vertex;
+        ComputeImpl(mesh, p0, p1);
+    }
+
+    /**
+     * @brief Compute the parameterized mesh with explicit pinned vertex indices
+     *
+     * @param pin0Idx Index of the first pinned vertex (placed at the UV origin)
+     * @param pin1Idx Index of the second pinned vertex (placed on the nearest axis)
+     * @throws SolverException If matrix cannot be decomposed or if solver fails
+     * to find a solution.
+     */
+    static void Compute(typename Mesh::Pointer& mesh, std::size_t pin0Idx, std::size_t pin1Idx)
+    {
+        ComputeImpl(mesh, mesh->vertex(pin0Idx), mesh->vertex(pin1Idx));
+    }
+
+private:
+    /** Optional explicit pin pair set via setPinnedVertices() */
+    std::optional<std::pair<std::size_t, std::size_t>> pinnedVertices_;
+
+    /**
+     * @brief Core solver: place p0/p1 on the UV axes then solve for free vertices
+     */
+    static void ComputeImpl(typename Mesh::Pointer& mesh, const typename Mesh::VertPtr& p0,
+                            const typename Mesh::VertPtr& p1)
+    {
+        using Triplet = Eigen::Triplet<T>;
+        using SparseMatrix = Eigen::SparseMatrix<T>;
+        using DenseMatrix = Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>;
 
         // Map selected edge to closest XY axis
         // Use sign to select direction

--- a/tests/src/TestParameterization.cpp
+++ b/tests/src/TestParameterization.cpp
@@ -230,3 +230,61 @@ TEST(Parameterizations, ABFPlusPlus_LooseThreshold)
 
     EXPECT_EQ(abf.iterations(), 0u);
 }
+
+TEST(Parameterization, AngleBasedLSCM_ExplicitPins)
+{
+    // Explicit pins matching the default selection must produce identical results
+    using LSCM = AngleBasedLSCM<float>;
+
+    auto mesh = ConstructPyramid<LSCM::Mesh>();
+    LSCM::Compute(mesh, 0, 1);
+
+    const std::vector expected{Vec3f{0, 0, 0}, Vec3f{2, 0, 0}, Vec3f{1, 1.0392305, 0},
+                               Vec3f{1, 0.34641013, 0}};
+    for (auto v = 0; v < mesh->num_vertices(); ++v) {
+        const auto& vv = mesh->vertex(v);
+        const auto& ve = expected[v];
+        for (auto i = 0; i < 3; i++) {
+            EXPECT_FLOAT_EQ(vv->pos[i], ve[i]);
+        }
+    }
+}
+
+TEST(Parameterization, AngleBasedLSCM_ExplicitPins_Reversed)
+{
+    // Swapping the pin pair must change which vertex lands at the origin
+    using LSCM = AngleBasedLSCM<float>;
+
+    auto mesh = ConstructPyramid<LSCM::Mesh>();
+    LSCM::Compute(mesh, 1, 0);
+
+    // p0 = vertex 1 → placed at {0, 0, 0}
+    // p1 = vertex 0 → edge from v1 to v0 is {-1,0,0}; max axis is Y (value 0),
+    //   copysign(dist=2, 0) = +2  →  p1 placed at {0, 2, 0}
+    EXPECT_FLOAT_EQ(mesh->vertex(1)->pos[0], 0.f);
+    EXPECT_FLOAT_EQ(mesh->vertex(1)->pos[1], 0.f);
+    EXPECT_FLOAT_EQ(mesh->vertex(0)->pos[0], 0.f);
+    EXPECT_FLOAT_EQ(mesh->vertex(0)->pos[1], 2.f);
+}
+
+TEST(Parameterization, AngleBasedLSCM_SetPinnedVertices)
+{
+    // Instance API: setPinnedVertices selects the same pins as the static overload
+    using LSCM = AngleBasedLSCM<float>;
+
+    auto mesh_static = ConstructPyramid<LSCM::Mesh>();
+    LSCM::Compute(mesh_static, 0, 1);
+
+    auto mesh_instance = ConstructPyramid<LSCM::Mesh>();
+    LSCM lscm;
+    lscm.setPinnedVertices(0, 1);
+    lscm.compute(mesh_instance);
+
+    for (auto v = 0; v < mesh_static->num_vertices(); ++v) {
+        const auto& vs = mesh_static->vertex(v)->pos;
+        const auto& vi = mesh_instance->vertex(v)->pos;
+        for (auto i = 0; i < 3; i++) {
+            EXPECT_FLOAT_EQ(vi[i], vs[i]);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Extracts the core solver into private `ComputeImpl(mesh, p0, p1)` — no logic duplication
- Adds `Compute(mesh, pin0Idx, pin1Idx)` static overload for explicit pin selection
- Adds `setPinnedVertices(pin0Idx, pin1Idx)` + stateful `pinnedVertices_` for the instance API
- Default `Compute(mesh)` is unchanged: auto-selects first boundary vertex + neighbor

## API

```cpp
// Default (unchanged behavior)
AngleBasedLSCM<float>::Compute(mesh);

// Static explicit pins
AngleBasedLSCM<float>::Compute(mesh, 0, 3);

// Instance explicit pins
AngleBasedLSCM<float> lscm;
lscm.setPinnedVertices(0, 3);
lscm.compute(mesh);
```

## Test plan
- [x] `AngleBasedLSCM_ExplicitPins` — `Compute(mesh, 0, 1)` produces bit-identical result to default
- [x] `AngleBasedLSCM_ExplicitPins_Reversed` — `Compute(mesh, 1, 0)` places the correct vertex at the origin and p1 on the Y axis
- [x] `AngleBasedLSCM_SetPinnedVertices` — instance API matches static explicit-pin overload
- [x] All 72 existing tests pass

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)