### PR TITLE
Fix edges_ staleness in split_edge; rename detail::filter; clean up exceptions

### DIFF
--- a/conductor/tracks.md
+++ b/conductor/tracks.md
@@ -25,6 +25,7 @@
 | open | F11 | Implement ACVD | [#62](https://github.com/educelab/OpenABF/issues/62) | 2026-03-20 | 2026-03-20 |
 | open | F2 | Multi-chart UV packing | [#18](https://github.com/educelab/OpenABF/issues/18) | 2026-03-13 | 2026-03-13 |
 | open | F3 | Multi-component extraction and parameterization pipeline | [#19](https://github.com/educelab/OpenABF/issues/19) | 2026-03-13 | 2026-03-13 |
+| ~ | M5 | split_edge and detail::filter cleanup | [#76](https://github.com/educelab/OpenABF/issues/76), [#77](https://github.com/educelab/OpenABF/issues/77), [#78](https://github.com/educelab/OpenABF/issues/78) | 2026-06-12 | 2026-06-12 |
 
 ## Archived Tracks
 

--- a/conductor/tracks/M5/plan.md
+++ b/conductor/tracks/M5/plan.md
@@ -1,0 +1,34 @@
+# M5 Implementation Plan
+
+## Phase 1 — Tests
+1. Add a unit test in `tests/src/TestHalfEdgeMesh.cpp` that constructs a
+   boundary vertex with a 3-triangle fan and attempts to split an edge in the
+   middle of the fan (the pinch case from #78). Expect `MeshException`.
+2. Confirm the test FAILS against current `split_edge` (silent corruption
+   rather than an exception).
+
+## Phase 2 — Implementation
+1. **#76** — Rename `detail::filter` → `detail::remove_if` at
+   `include/OpenABF/HalfEdgeMesh.hpp:59`. Update all 6 call sites
+   (`:1041, :1054, :1333, :1335, :1356, :1358`). Predicates unchanged.
+2. **#77** — Replace the two exception messages in `split_edge` (at the new
+   line numbers after rename) with `"Non-manifold boundary vertex at split
+   endpoint"`. Drop the `== 0` branch entirely since it is unreachable given
+   the surrounding `startOnBoundary`/`endOnBoundary` checks. Remove
+   `newFwd->prev->pair->vertex = newStart;` at line 1411.
+3. **#78** — Before mutating in `split_edge`, validate the precondition: when
+   `startOnBoundary`, walk from `startOut->pair` via `prev` (or from `startIn`
+   via `next`) and confirm the traversal reaches `oldFwd` without leaving
+   `oldFwd`'s face. If not, throw `MeshException("split_edge: would create
+   non-manifold pinched vertex")`. Symmetric check at `oldEnd`.
+
+## Phase 3 — Verify
+- `git clang-format` against staged changes.
+- Run `python3 thirdparty/amalgamate/amalgamate.py -c single_include.json -s .`
+  to regenerate `single_include/OpenABF/OpenABF.hpp`.
+- Run full `ctest` and confirm all tests pass.
+
+## Phase 4 — Ship
+- Push branch `cleanup/split-edge-and-filter`.
+- Open draft PR with `Fixes #76`, `Fixes #77`, `Fixes #78` in the body so the
+  Development feature auto-links all three issues.

--- a/conductor/tracks/M5/spec.md
+++ b/conductor/tracks/M5/spec.md
@@ -1,0 +1,48 @@
+# M5 — split_edge and detail::filter cleanup
+
+## GitHub Issues
+- https://github.com/educelab/OpenABF/issues/76 — `detail::filter` has remove_if semantics
+- https://github.com/educelab/OpenABF/issues/77 — split_edge: misleading exception messages and redundant vertex update
+- https://github.com/educelab/OpenABF/issues/78 — split_edge: undetected non-manifold pinch when splitting interior fan edge at boundary vertex
+
+## Summary
+Three related code-quality issues surfaced during a review of
+`HalfEdgeMesh::split_edge`. They all touch `include/OpenABF/HalfEdgeMesh.hpp`
+within ~250 lines of each other and are bundled here to avoid churning the
+same code three times.
+
+1. **#76** — `detail::filter` (`HalfEdgeMesh.hpp:57-64`) is implemented with
+   `std::remove_if`. It discards elements matching the predicate and keeps the
+   rest — the opposite of the conventional `filter` semantic. Rename it to
+   `detail::remove_if` (matches STL convention; minimum-churn fix).
+2. **#77** — `split_edge` (`:1337-1342`, `:1360-1365`) throws
+   `"No incoming/outgoing edges"` / `"Too many incoming/outgoing edges"` when
+   the filtered list of *boundary* in/out edges has the wrong cardinality.
+   Update messages to reflect that. Also remove the redundant
+   `newFwd->prev->pair->vertex = newStart;` at `:1411` — it is set again at
+   `:1415` in the boundary branch and is a no-op in the non-boundary branch.
+3. **#78** — `split_edge` silently produces a non-manifold pinched vertex if
+   the edge being split lives in the *middle* of a triangle fan at a boundary
+   vertex (rather than at one end of the fan). Add a precondition check that
+   throws a clear `MeshException` instead.
+
+## Acceptance Criteria
+- [ ] `detail::filter` is renamed to `detail::remove_if`; all call sites
+      updated; predicate semantics unchanged.
+- [ ] `split_edge` exception messages mention "boundary" so the failure mode
+      is identifiable from the message alone.
+- [ ] Redundant assignment at line 1411 is removed.
+- [ ] `split_edge` throws a `MeshException` when called on an edge whose face
+      is not adjacent to the existing boundary at either endpoint, instead of
+      silently producing a non-manifold mesh.
+- [ ] New unit test exercises the pinch case and expects the exception.
+- [ ] All existing tests pass unchanged.
+- [ ] `single_include/OpenABF/OpenABF.hpp` regenerated.
+
+## Dependencies
+None — independent of the active feature tracks.
+
+## Out of scope
+- F3 multi-component pipeline (separate track, separate PR).
+- Larger refactors of `split_edge` (e.g. splitting the boundary/non-boundary
+  branches into helpers) — defer to a follow-up if desired.

--- a/include/OpenABF/HalfEdgeMesh.hpp
+++ b/include/OpenABF/HalfEdgeMesh.hpp
@@ -54,9 +54,13 @@ auto vec_to_string(const T& v) -> std::string
     return ss.str();
 }
 
-/** Remove elements which meet the given predicate */
+/**
+ * Returns a copy of @p v with every element matching @p p removed. Naming
+ * matches std::remove_if (predicate selects elements to drop), NOT the
+ * conventional `filter` semantic where the predicate selects what to keep.
+ */
 template <class ForwardContainer, class UnaryPred>
-auto filter(ForwardContainer v, UnaryPred p)
+auto remove_if(ForwardContainer v, UnaryPred p)
 {
     auto end = std::remove_if(std::begin(v), std::end(v), p);
     v.erase(end, std::end(v));
@@ -1038,8 +1042,8 @@ public:
             if (edge->is_boundary()) {
                 // Get incoming boundary edges to the start point
                 auto inBoundary =
-                    detail::filter(incoming_edges(edge->vertex->idx),
-                                   [](const auto& e) { return not e->is_boundary(); });
+                    detail::remove_if(incoming_edges(edge->vertex->idx),
+                                      [](const auto& e) { return not e->is_boundary(); });
                 if (inBoundary.size() == 0 or inBoundary.size() > 1) {
                     const std::array<std::size_t, 2> idx{edge->vertex->idx,
                                                          edge->pair->vertex->idx};
@@ -1051,8 +1055,8 @@ public:
 
                 // Get outgoing boundary edges to the end point
                 auto outBoundary =
-                    detail::filter(outgoing_edges(edge->pair->vertex->idx),
-                                   [](const auto& e) { return not e->is_boundary(); });
+                    detail::remove_if(outgoing_edges(edge->pair->vertex->idx),
+                                      [](const auto& e) { return not e->is_boundary(); });
                 if (outBoundary.size() == 0 or outBoundary.size() > 1) {
                     const std::array<std::size_t, 2> idx{edge->vertex->idx,
                                                          edge->pair->vertex->idx};
@@ -1323,22 +1327,22 @@ public:
         auto startOnBoundary = oldStart->is_boundary();
         auto endOnBoundary = oldEnd->is_boundary();
 
-        // Get the new starting vertex for this edge
+        // Get the new starting vertex for this edge. detail::remove_if keeps
+        // only boundary half-edges (predicate selects what to drop). A
+        // manifold boundary vertex has exactly one boundary half-edge in each
+        // direction; more than one means a non-manifold split endpoint.
         VertPtr newStart;
         EdgePtr startIn, startOut;
         if (startOnBoundary) {
             auto newIdx = insert_vertex(oldStart->pos);
             newStart = verts_.at(newIdx);
 
-            auto in = detail::filter(incoming_edges(oldStart->idx),
-                                     [](auto e) { return not e->is_boundary(); });
-            auto out = detail::filter(outgoing_edges(oldStart->idx),
-                                      [](auto e) { return not e->is_boundary(); });
-            if (in.size() == 0 or out.size() == 0) {
-                throw MeshException("No incoming/outgoing edges");
-            }
-            if (in.size() > 1 or out.size() > 1) {
-                throw MeshException("Too many incoming/outgoing edges");
+            auto in = detail::remove_if(incoming_edges(oldStart->idx),
+                                        [](auto e) { return not e->is_boundary(); });
+            auto out = detail::remove_if(outgoing_edges(oldStart->idx),
+                                         [](auto e) { return not e->is_boundary(); });
+            if (in.size() != 1 or out.size() != 1) {
+                throw MeshException("Non-manifold boundary vertex at split endpoint");
             }
             startIn = in[0];
             startOut = out[0];
@@ -1353,15 +1357,12 @@ public:
             auto newIdx = insert_vertex(oldEnd->pos);
             newEnd = verts_.at(newIdx);
 
-            auto in = detail::filter(incoming_edges(oldEnd->idx),
-                                     [](auto e) { return not e->is_boundary(); });
-            auto out = detail::filter(outgoing_edges(oldEnd->idx),
-                                      [](auto e) { return not e->is_boundary(); });
-            if (in.size() == 0 or out.size() == 0) {
-                throw MeshException("No incoming/outgoing edges");
-            }
-            if (in.size() > 1 or out.size() > 1) {
-                throw MeshException("Too many incoming/outgoing edges");
+            auto in = detail::remove_if(incoming_edges(oldEnd->idx),
+                                        [](auto e) { return not e->is_boundary(); });
+            auto out = detail::remove_if(outgoing_edges(oldEnd->idx),
+                                         [](auto e) { return not e->is_boundary(); });
+            if (in.size() != 1 or out.size() != 1) {
+                throw MeshException("Non-manifold boundary vertex at split endpoint");
             }
             endIn = in[0];
             endOut = out[0];
@@ -1404,21 +1405,34 @@ public:
             newFwd->face->head = newFwd;
         }
 
-        // Update the face's edges
+        // Re-link neighbors of newFwd in the inherited face.
+        //
+        // newFwd->next (second half-edge of the face) needs to originate at
+        // newEnd, which it does unconditionally below — a no-op when
+        // endOnBoundary is false (newEnd == oldEnd).
+        //
+        // The neighboring half-edge across newFwd->prev (newFwd->prev->pair)
+        // also originates at newStart in the boundary branch, but it is
+        // ALWAYS covered downstream: it is either startOut itself (when the
+        // existing boundary at oldStart sits across newFwd->prev — the
+        // SimpleSplit case) and updated by the `startOut->vertex = newStart`
+        // assignment, or it is a non-boundary edge in newStart's fan and
+        // updated by the wheel loop below.
         newFwd->next->prev = newFwd;
         newFwd->prev->next = newFwd;
-        newFwd->next->vertex = newEnd;
-        newFwd->prev->pair->vertex = newStart;
+        rekey_edge_to_vertex(newFwd->next, newEnd);
 
-        // Update new boundary edges' next/prev
+        // Update new boundary edges' next/prev. The rekey_* calls move
+        // half-edges between edges_ multimap buckets so that
+        // outgoing_edges(idx) / Vertex::is_manifold() remain consistent.
         if (startOnBoundary) {
-            startOut->vertex = newStart;
+            rekey_edge_to_vertex(startOut, newStart);
             newBwd->next = startOut;
             startOut->prev = newBwd;
             oldFwd->prev = startIn;
             startIn->next = oldFwd;
             for (auto e : newStart->wheel()) {
-                e->vertex = newStart;
+                rekey_edge_to_vertex(e, newStart);
             }
         } else {
             newBwd->next = oldFwd;
@@ -1430,7 +1444,7 @@ public:
             oldFwd->next = endOut;
             endOut->prev = oldFwd;
             for (auto e : newEnd->wheel()) {
-                e->vertex = newEnd;
+                rekey_edge_to_vertex(e, newEnd);
             }
         } else {
             newBwd->prev = oldFwd;
@@ -1475,6 +1489,32 @@ public:
         }
 
         split_path(edgePath);
+    }
+
+    /**
+     * @brief Move @p e from its current edges_ bucket to the bucket keyed by
+     * @p newVert and update e->vertex.
+     *
+     * The edges_ multimap is keyed by half-edge origin vertex index. Any code
+     * that reassigns a half-edge's origin (e.g. split_edge duplicating a
+     * vertex and moving a fan of half-edges to the new vertex) must call this
+     * to keep the multimap consistent, otherwise outgoing_edges() /
+     * incoming_edges() / Vertex::is_manifold() return stale results.
+     */
+    void rekey_edge_to_vertex(const EdgePtr& e, const VertPtr& newVert)
+    {
+        if (e->vertex == newVert) {
+            return;
+        }
+        const auto range = edges_.equal_range(e->vertex->idx);
+        for (auto it = range.first; it != range.second; ++it) {
+            if (it->second == e) {
+                edges_.erase(it);
+                break;
+            }
+        }
+        edges_.emplace(newVert->idx, e);
+        e->vertex = newVert;
     }
 
     /** @brief Get a list of outgoing edges from a specific vertex (by index) */

--- a/include/OpenABF/HalfEdgeMesh.hpp
+++ b/include/OpenABF/HalfEdgeMesh.hpp
@@ -1420,19 +1420,19 @@ public:
         // updated by the wheel loop below.
         newFwd->next->prev = newFwd;
         newFwd->prev->next = newFwd;
-        rekey_edge_to_vertex(newFwd->next, newEnd);
+        rekey_edge_to_vertex_(newFwd->next, newEnd);
 
         // Update new boundary edges' next/prev. The rekey_* calls move
         // half-edges between edges_ multimap buckets so that
         // outgoing_edges(idx) / Vertex::is_manifold() remain consistent.
         if (startOnBoundary) {
-            rekey_edge_to_vertex(startOut, newStart);
+            rekey_edge_to_vertex_(startOut, newStart);
             newBwd->next = startOut;
             startOut->prev = newBwd;
             oldFwd->prev = startIn;
             startIn->next = oldFwd;
             for (auto e : newStart->wheel()) {
-                rekey_edge_to_vertex(e, newStart);
+                rekey_edge_to_vertex_(e, newStart);
             }
         } else {
             newBwd->next = oldFwd;
@@ -1444,7 +1444,7 @@ public:
             oldFwd->next = endOut;
             endOut->prev = oldFwd;
             for (auto e : newEnd->wheel()) {
-                rekey_edge_to_vertex(e, newEnd);
+                rekey_edge_to_vertex_(e, newEnd);
             }
         } else {
             newBwd->prev = oldFwd;
@@ -1491,32 +1491,6 @@ public:
         split_path(edgePath);
     }
 
-    /**
-     * @brief Move @p e from its current edges_ bucket to the bucket keyed by
-     * @p newVert and update e->vertex.
-     *
-     * The edges_ multimap is keyed by half-edge origin vertex index. Any code
-     * that reassigns a half-edge's origin (e.g. split_edge duplicating a
-     * vertex and moving a fan of half-edges to the new vertex) must call this
-     * to keep the multimap consistent, otherwise outgoing_edges() /
-     * incoming_edges() / Vertex::is_manifold() return stale results.
-     */
-    void rekey_edge_to_vertex(const EdgePtr& e, const VertPtr& newVert)
-    {
-        if (e->vertex == newVert) {
-            return;
-        }
-        const auto range = edges_.equal_range(e->vertex->idx);
-        for (auto it = range.first; it != range.second; ++it) {
-            if (it->second == e) {
-                edges_.erase(it);
-                break;
-            }
-        }
-        edges_.emplace(newVert->idx, e);
-        e->vertex = newVert;
-    }
-
     /** @brief Get a list of outgoing edges from a specific vertex (by index) */
     auto outgoing_edges(const std::size_t idx) -> std::vector<EdgePtr>
     {
@@ -1540,6 +1514,32 @@ public:
     }
 
 private:
+    /**
+     * Move @p e from its current edges_ bucket to the bucket keyed by
+     * @p newVert, and update e->vertex.
+     *
+     * edges_ is a multimap keyed by half-edge origin vertex index. Any code
+     * that reassigns a half-edge's origin (e.g. split_edge duplicating a
+     * vertex and moving a fan of half-edges to the new vertex) must call
+     * this to keep the multimap consistent, otherwise outgoing_edges() /
+     * incoming_edges() / Vertex::is_manifold() return stale results.
+     */
+    void rekey_edge_to_vertex_(const EdgePtr& e, const VertPtr& newVert)
+    {
+        if (e->vertex == newVert) {
+            return;
+        }
+        const auto range = edges_.equal_range(e->vertex->idx);
+        for (auto it = range.first; it != range.second; ++it) {
+            if (it->second == e) {
+                edges_.erase(it);
+                break;
+            }
+        }
+        edges_.emplace(newVert->idx, e);
+        e->vertex = newVert;
+    }
+
     /**
      * Face insertion implementation
      *

--- a/single_include/OpenABF/OpenABF.hpp
+++ b/single_include/OpenABF/OpenABF.hpp
@@ -498,9 +498,13 @@ auto vec_to_string(const T& v) -> std::string
     return ss.str();
 }
 
-/** Remove elements which meet the given predicate */
+/**
+ * Returns a copy of @p v with every element matching @p p removed. Naming
+ * matches std::remove_if (predicate selects elements to drop), NOT the
+ * conventional `filter` semantic where the predicate selects what to keep.
+ */
 template <class ForwardContainer, class UnaryPred>
-auto filter(ForwardContainer v, UnaryPred p)
+auto remove_if(ForwardContainer v, UnaryPred p)
 {
     auto end = std::remove_if(std::begin(v), std::end(v), p);
     v.erase(end, std::end(v));
@@ -1482,8 +1486,8 @@ public:
             if (edge->is_boundary()) {
                 // Get incoming boundary edges to the start point
                 auto inBoundary =
-                    detail::filter(incoming_edges(edge->vertex->idx),
-                                   [](const auto& e) { return not e->is_boundary(); });
+                    detail::remove_if(incoming_edges(edge->vertex->idx),
+                                      [](const auto& e) { return not e->is_boundary(); });
                 if (inBoundary.size() == 0 or inBoundary.size() > 1) {
                     const std::array<std::size_t, 2> idx{edge->vertex->idx,
                                                          edge->pair->vertex->idx};
@@ -1495,8 +1499,8 @@ public:
 
                 // Get outgoing boundary edges to the end point
                 auto outBoundary =
-                    detail::filter(outgoing_edges(edge->pair->vertex->idx),
-                                   [](const auto& e) { return not e->is_boundary(); });
+                    detail::remove_if(outgoing_edges(edge->pair->vertex->idx),
+                                      [](const auto& e) { return not e->is_boundary(); });
                 if (outBoundary.size() == 0 or outBoundary.size() > 1) {
                     const std::array<std::size_t, 2> idx{edge->vertex->idx,
                                                          edge->pair->vertex->idx};
@@ -1767,22 +1771,22 @@ public:
         auto startOnBoundary = oldStart->is_boundary();
         auto endOnBoundary = oldEnd->is_boundary();
 
-        // Get the new starting vertex for this edge
+        // Get the new starting vertex for this edge. detail::remove_if keeps
+        // only boundary half-edges (predicate selects what to drop). A
+        // manifold boundary vertex has exactly one boundary half-edge in each
+        // direction; more than one means a non-manifold split endpoint.
         VertPtr newStart;
         EdgePtr startIn, startOut;
         if (startOnBoundary) {
             auto newIdx = insert_vertex(oldStart->pos);
             newStart = verts_.at(newIdx);
 
-            auto in = detail::filter(incoming_edges(oldStart->idx),
-                                     [](auto e) { return not e->is_boundary(); });
-            auto out = detail::filter(outgoing_edges(oldStart->idx),
-                                      [](auto e) { return not e->is_boundary(); });
-            if (in.size() == 0 or out.size() == 0) {
-                throw MeshException("No incoming/outgoing edges");
-            }
-            if (in.size() > 1 or out.size() > 1) {
-                throw MeshException("Too many incoming/outgoing edges");
+            auto in = detail::remove_if(incoming_edges(oldStart->idx),
+                                        [](auto e) { return not e->is_boundary(); });
+            auto out = detail::remove_if(outgoing_edges(oldStart->idx),
+                                         [](auto e) { return not e->is_boundary(); });
+            if (in.size() != 1 or out.size() != 1) {
+                throw MeshException("Non-manifold boundary vertex at split endpoint");
             }
             startIn = in[0];
             startOut = out[0];
@@ -1797,15 +1801,12 @@ public:
             auto newIdx = insert_vertex(oldEnd->pos);
             newEnd = verts_.at(newIdx);
 
-            auto in = detail::filter(incoming_edges(oldEnd->idx),
-                                     [](auto e) { return not e->is_boundary(); });
-            auto out = detail::filter(outgoing_edges(oldEnd->idx),
-                                      [](auto e) { return not e->is_boundary(); });
-            if (in.size() == 0 or out.size() == 0) {
-                throw MeshException("No incoming/outgoing edges");
-            }
-            if (in.size() > 1 or out.size() > 1) {
-                throw MeshException("Too many incoming/outgoing edges");
+            auto in = detail::remove_if(incoming_edges(oldEnd->idx),
+                                        [](auto e) { return not e->is_boundary(); });
+            auto out = detail::remove_if(outgoing_edges(oldEnd->idx),
+                                         [](auto e) { return not e->is_boundary(); });
+            if (in.size() != 1 or out.size() != 1) {
+                throw MeshException("Non-manifold boundary vertex at split endpoint");
             }
             endIn = in[0];
             endOut = out[0];
@@ -1848,21 +1849,34 @@ public:
             newFwd->face->head = newFwd;
         }
 
-        // Update the face's edges
+        // Re-link neighbors of newFwd in the inherited face.
+        //
+        // newFwd->next (second half-edge of the face) needs to originate at
+        // newEnd, which it does unconditionally below — a no-op when
+        // endOnBoundary is false (newEnd == oldEnd).
+        //
+        // The neighboring half-edge across newFwd->prev (newFwd->prev->pair)
+        // also originates at newStart in the boundary branch, but it is
+        // ALWAYS covered downstream: it is either startOut itself (when the
+        // existing boundary at oldStart sits across newFwd->prev — the
+        // SimpleSplit case) and updated by the `startOut->vertex = newStart`
+        // assignment, or it is a non-boundary edge in newStart's fan and
+        // updated by the wheel loop below.
         newFwd->next->prev = newFwd;
         newFwd->prev->next = newFwd;
-        newFwd->next->vertex = newEnd;
-        newFwd->prev->pair->vertex = newStart;
+        rekey_edge_to_vertex(newFwd->next, newEnd);
 
-        // Update new boundary edges' next/prev
+        // Update new boundary edges' next/prev. The rekey_* calls move
+        // half-edges between edges_ multimap buckets so that
+        // outgoing_edges(idx) / Vertex::is_manifold() remain consistent.
         if (startOnBoundary) {
-            startOut->vertex = newStart;
+            rekey_edge_to_vertex(startOut, newStart);
             newBwd->next = startOut;
             startOut->prev = newBwd;
             oldFwd->prev = startIn;
             startIn->next = oldFwd;
             for (auto e : newStart->wheel()) {
-                e->vertex = newStart;
+                rekey_edge_to_vertex(e, newStart);
             }
         } else {
             newBwd->next = oldFwd;
@@ -1874,7 +1888,7 @@ public:
             oldFwd->next = endOut;
             endOut->prev = oldFwd;
             for (auto e : newEnd->wheel()) {
-                e->vertex = newEnd;
+                rekey_edge_to_vertex(e, newEnd);
             }
         } else {
             newBwd->prev = oldFwd;
@@ -1919,6 +1933,32 @@ public:
         }
 
         split_path(edgePath);
+    }
+
+    /**
+     * @brief Move @p e from its current edges_ bucket to the bucket keyed by
+     * @p newVert and update e->vertex.
+     *
+     * The edges_ multimap is keyed by half-edge origin vertex index. Any code
+     * that reassigns a half-edge's origin (e.g. split_edge duplicating a
+     * vertex and moving a fan of half-edges to the new vertex) must call this
+     * to keep the multimap consistent, otherwise outgoing_edges() /
+     * incoming_edges() / Vertex::is_manifold() return stale results.
+     */
+    void rekey_edge_to_vertex(const EdgePtr& e, const VertPtr& newVert)
+    {
+        if (e->vertex == newVert) {
+            return;
+        }
+        const auto range = edges_.equal_range(e->vertex->idx);
+        for (auto it = range.first; it != range.second; ++it) {
+            if (it->second == e) {
+                edges_.erase(it);
+                break;
+            }
+        }
+        edges_.emplace(newVert->idx, e);
+        e->vertex = newVert;
     }
 
     /** @brief Get a list of outgoing edges from a specific vertex (by index) */

--- a/single_include/OpenABF/OpenABF.hpp
+++ b/single_include/OpenABF/OpenABF.hpp
@@ -1864,19 +1864,19 @@ public:
         // updated by the wheel loop below.
         newFwd->next->prev = newFwd;
         newFwd->prev->next = newFwd;
-        rekey_edge_to_vertex(newFwd->next, newEnd);
+        rekey_edge_to_vertex_(newFwd->next, newEnd);
 
         // Update new boundary edges' next/prev. The rekey_* calls move
         // half-edges between edges_ multimap buckets so that
         // outgoing_edges(idx) / Vertex::is_manifold() remain consistent.
         if (startOnBoundary) {
-            rekey_edge_to_vertex(startOut, newStart);
+            rekey_edge_to_vertex_(startOut, newStart);
             newBwd->next = startOut;
             startOut->prev = newBwd;
             oldFwd->prev = startIn;
             startIn->next = oldFwd;
             for (auto e : newStart->wheel()) {
-                rekey_edge_to_vertex(e, newStart);
+                rekey_edge_to_vertex_(e, newStart);
             }
         } else {
             newBwd->next = oldFwd;
@@ -1888,7 +1888,7 @@ public:
             oldFwd->next = endOut;
             endOut->prev = oldFwd;
             for (auto e : newEnd->wheel()) {
-                rekey_edge_to_vertex(e, newEnd);
+                rekey_edge_to_vertex_(e, newEnd);
             }
         } else {
             newBwd->prev = oldFwd;
@@ -1935,32 +1935,6 @@ public:
         split_path(edgePath);
     }
 
-    /**
-     * @brief Move @p e from its current edges_ bucket to the bucket keyed by
-     * @p newVert and update e->vertex.
-     *
-     * The edges_ multimap is keyed by half-edge origin vertex index. Any code
-     * that reassigns a half-edge's origin (e.g. split_edge duplicating a
-     * vertex and moving a fan of half-edges to the new vertex) must call this
-     * to keep the multimap consistent, otherwise outgoing_edges() /
-     * incoming_edges() / Vertex::is_manifold() return stale results.
-     */
-    void rekey_edge_to_vertex(const EdgePtr& e, const VertPtr& newVert)
-    {
-        if (e->vertex == newVert) {
-            return;
-        }
-        const auto range = edges_.equal_range(e->vertex->idx);
-        for (auto it = range.first; it != range.second; ++it) {
-            if (it->second == e) {
-                edges_.erase(it);
-                break;
-            }
-        }
-        edges_.emplace(newVert->idx, e);
-        e->vertex = newVert;
-    }
-
     /** @brief Get a list of outgoing edges from a specific vertex (by index) */
     auto outgoing_edges(const std::size_t idx) -> std::vector<EdgePtr>
     {
@@ -1984,6 +1958,32 @@ public:
     }
 
 private:
+    /**
+     * Move @p e from its current edges_ bucket to the bucket keyed by
+     * @p newVert, and update e->vertex.
+     *
+     * edges_ is a multimap keyed by half-edge origin vertex index. Any code
+     * that reassigns a half-edge's origin (e.g. split_edge duplicating a
+     * vertex and moving a fan of half-edges to the new vertex) must call
+     * this to keep the multimap consistent, otherwise outgoing_edges() /
+     * incoming_edges() / Vertex::is_manifold() return stale results.
+     */
+    void rekey_edge_to_vertex_(const EdgePtr& e, const VertPtr& newVert)
+    {
+        if (e->vertex == newVert) {
+            return;
+        }
+        const auto range = edges_.equal_range(e->vertex->idx);
+        for (auto it = range.first; it != range.second; ++it) {
+            if (it->second == e) {
+                edges_.erase(it);
+                break;
+            }
+        }
+        edges_.emplace(newVert->idx, e);
+        e->vertex = newVert;
+    }
+
     /**
      * Face insertion implementation
      *

--- a/tests/src/TestHalfEdgeMesh.cpp
+++ b/tests/src/TestHalfEdgeMesh.cpp
@@ -197,6 +197,41 @@ TEST(HalfEdgeMesh, SimpleSplit)
     EXPECT_EQ(mesh->num_connected_components(), 2);
 }
 
+TEST(HalfEdgeMesh, SplitMidFanAtBoundaryVertex)
+{
+    // 3-triangle fan around boundary vertex v0. The fan is open between v1
+    // (right) and v4 (left); the existing boundary at v0 has incoming half-edge
+    // 1->0 and outgoing half-edge 0->4. Splitting edge 0->2 (the middle of the
+    // fan) was speculated to produce a pinched non-manifold vertex; verify
+    // empirically that the partition is clean: {T_a} on one side, {T_b, T_c}
+    // on the other, two connected components.
+    const auto mesh = MeshType::New();
+    mesh->insert_vertices({
+        {0.f, 0.f, 0.f},    // v0 — fan center, on boundary
+        {1.f, 0.f, 0.f},    // v1 — right fan end
+        {0.5f, 1.f, 0.f},   // v2
+        {-0.5f, 1.f, 0.f},  // v3
+        {-1.f, 0.f, 0.f},   // v4 — left fan end
+    });
+    mesh->insert_faces({{0, 1, 2}, {0, 2, 3}, {0, 3, 4}});
+    EXPECT_EQ(mesh->num_connected_components(), 1);
+
+    // Split the middle edge of the fan (between T_a and T_b)
+    mesh->split_path({0, 2});
+    EXPECT_EQ(mesh->num_connected_components(), 2);
+
+    // Boundary cycles should partition cleanly: one short cycle around the
+    // detached T_a, one longer cycle around the T_b U T_c piece.
+    const auto loops = mesh->boundaries();
+    ASSERT_EQ(loops.size(), 2u);
+    EXPECT_NE(loops[0].size(), loops[1].size());  // 3 vs 4
+
+    // Every vertex on the resulting mesh must be manifold
+    for (const auto& v : mesh->vertices()) {
+        EXPECT_TRUE(v->is_manifold()) << "vertex " << v->idx << " is non-manifold";
+    }
+}
+
 TEST(HalfEdgeMesh, TwoStageSplit)
 {
     // Build a mesh


### PR DESCRIPTION
Bundles three related issues that all touch `HalfEdgeMesh::split_edge` and its immediate neighborhood. Conductor track: [M5](conductor/tracks/M5/spec.md).

## Summary

- **Fixes #76** — `detail::filter` was a `std::remove_if` wearing a `filter` mask: the predicate selects elements to **drop**, not keep. Renamed to `detail::remove_if` (matches STL convention; minimum-churn fix). All six call sites updated; predicates unchanged.

- **Fixes #77** — `split_edge` threw `"No incoming/outgoing edges"` / `"Too many incoming/outgoing edges"` when its boundary in/out lists had unexpected sizes. The actual condition was "non-manifold boundary vertex"; message and check now reflect that (single `!= 1` test). Also removed the redundant `newFwd->prev->pair->vertex = newStart;` line — that half-edge is always covered downstream, either by `startOut->vertex = newStart` (when it equals `startOut`) or by the wheel loop (when it does not). Source comment explains both cases.

- **Fixes #78** — `split_edge` updated half-edge `vertex` pointers via the wheel loops and via `startOut`/`newFwd->next` assignments but never re-keyed the `edges_` multimap. After a split, `outgoing_edges(idx)` returned stale entries, and `Vertex::is_manifold` (which reads the multimap by index) reported `false` on geometrically-manifold meshes. Added a private `rekey_edge_to_vertex(e, newVert)` helper that moves a half-edge between buckets and updates `e->vertex` atomically; threaded through all four sites in `split_edge` that change a half-edge's origin.

The pinch case originally filed in #78 turned out to be a data-structure bookkeeping bug, not a topological one. The GH issue body has been updated to reflect the actual root cause.

## Test plan
- [x] New regression test `HalfEdgeMesh.SplitMidFanAtBoundaryVertex` — 3-triangle fan at a boundary vertex, split the middle edge, verify the partition is clean (2 boundary loops, correct sizes) and every vertex remains manifold. Fails against the prior implementation, passes with this PR.
- [x] All 24 prior `OpenABF_TestHalfEdgeMesh` tests pass unchanged.
- [x] Full `ctest` (6/6 suites) passes.
- [x] `openabf_example_split_path` and `openabf_example_basic_flattening` build and run with expected output.
- [x] `single_include/OpenABF/OpenABF.hpp` regenerated via `thirdparty/amalgamate/amalgamate.py` and committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)