### PR TITLE
Add face_map to ExtractedComponent

### DIFF
--- a/examples/src/MultiChartFlatten.cpp
+++ b/examples/src/MultiChartFlatten.cpp
@@ -54,30 +54,33 @@ int main()
     mesh->split_path({1, 4, 7});
     std::cout << "After split:  " << mesh->num_connected_components() << " component(s)\n";
 
-    // Extract each connected component as an independent mesh. The back-map
-    // we get alongside each chart is the bridge between chart-vertex-idx and
-    // the original-mesh vertex-idx; downstream code that needs to scatter
-    // results back (e.g. a wedge UV table for mesh IO) uses it.
+    // Extract each connected component as an independent mesh. Each chart
+    // comes with a `vertex_map` and `face_map` that bridge chart indices to
+    // source-mesh indices; downstream code that scatters per-vertex or
+    // per-face data back to the source (e.g. wedge UV tables, per-face
+    // material assignments) uses them.
     auto charts = mesh->extract_connected_components();
     std::cout << "Extracted " << charts.size() << " chart(s)\n";
 
     // Flatten each chart in isolation and write it out as its own .obj.
     for (std::size_t i = 0; i < charts.size(); ++i) {
-        auto& [chart, backMap] = charts[i];
+        auto& cc = charts[i];
 
         std::size_t iters{0};
         float grad{OpenABF::INF<float>};
-        ABF::Compute(chart, iters, grad);
-        LSCM::Compute(chart);
+        ABF::Compute(cc.mesh, iters, grad);
+        LSCM::Compute(cc.mesh);
 
         const auto out = "openabf_example_multi_chart_" + std::to_string(i) + ".obj";
-        OpenABF::WriteMesh(out, chart);
-        std::cout << "Chart " << i << ": " << chart->num_vertices() << " vertices, "
-                  << chart->num_faces() << " faces, " << iters << " ABF++ iters -> " << out << "\n";
+        OpenABF::WriteMesh(out, cc.mesh);
+        std::cout << "Chart " << i << ": " << cc.mesh->num_vertices() << " vertices, "
+                  << cc.mesh->num_faces() << " faces, " << iters << " ABF++ iters -> " << out
+                  << "\n";
 
-        // back_map[chart_idx] -> original_idx, available for downstream uses
-        // such as building a per-wedge UV map keyed by the source mesh.
-        (void)backMap;
+        // cc.vertex_map[chart_idx] -> original vertex idx
+        // cc.face_map[chart_idx]   -> original face idx
+        // Available for downstream uses such as building a per-wedge UV map
+        // keyed by source-mesh face corners.
     }
 
     // The source mesh's 3D vertex positions are unchanged by the per-chart

--- a/include/OpenABF/HalfEdgeMesh.hpp
+++ b/include/OpenABF/HalfEdgeMesh.hpp
@@ -1251,26 +1251,44 @@ public:
     }
 
     /**
+     * @brief One element of `extract_connected_components()`'s output.
+     *
+     * Holds an extracted sub-mesh and the two index maps callers need to
+     * relate sub-mesh elements back to the source mesh. The mapping is 1-to-1
+     * in both directions for a manifold input — every source vertex/face is
+     * in exactly one component.
+     */
+    struct ExtractedComponent {
+        /** Deep copy of the connected component as an independent mesh. */
+        Pointer mesh;
+        /** `vertex_map[sub_idx] == original_idx`. */
+        std::vector<std::size_t> vertex_map;
+        /** `face_map[sub_idx] == original_idx`. */
+        std::vector<std::size_t> face_map;
+    };
+
+    /**
      * @brief Extract each connected component of this mesh into its own
      * independent mesh.
      *
-     * Returns one `(extracted_mesh, back_map)` pair per connected component.
-     * The extracted meshes are deep copies that preserve VertexTraits,
-     * EdgeTraits, and FaceTraits via the relevant copy constructors. Vertex
-     * indices in the extracted meshes are re-densified to `0..N-1` and
-     * `back_map[extracted_idx] == original_idx` lets callers scatter
-     * per-vertex results from the sub-mesh back onto the source.
+     * Returns one `ExtractedComponent` per connected component. The extracted
+     * meshes are deep copies that preserve VertexTraits, EdgeTraits, and
+     * FaceTraits via the relevant copy constructors. Vertex and face indices
+     * in the extracted meshes are re-densified to `0..N-1`; the `vertex_map`
+     * and `face_map` let callers scatter/gather per-vertex and per-face data
+     * between the sub-mesh and the source.
      *
      * A single-component mesh produces a vector of length 1 whose extracted
-     * mesh is equivalent to `clone()` and whose back-map is the identity.
+     * mesh is equivalent to `clone()` and whose maps are both the identity.
      */
-    auto extract_connected_components() -> std::vector<std::pair<Pointer, std::vector<std::size_t>>>
+    auto extract_connected_components() -> std::vector<ExtractedComponent>
     {
-        std::vector<std::pair<Pointer, std::vector<std::size_t>>> result;
+        std::vector<ExtractedComponent> result;
         for (const auto& component : connected_components()) {
-            auto sub = HalfEdgeMesh::New();
+            ExtractedComponent out;
+            out.mesh = HalfEdgeMesh::New();
             std::unordered_map<std::size_t, std::size_t> remap;
-            std::vector<std::size_t> backMap;
+            out.face_map.reserve(component.size());
 
             // Insert vertices first so the sub-mesh has the targets that
             // clone_face_ will look up via verts_.at(...). Copy ctor here
@@ -1279,24 +1297,27 @@ public:
                 for (const auto& edge : *face) {
                     const auto& v = edge->vertex;
                     if (remap.find(v->idx) == remap.end()) {
-                        const auto newIdx = sub->insert_vertex(*v);
-                        sub->verts_[newIdx]->edge = nullptr;
+                        const auto newIdx = out.mesh->insert_vertex(*v);
+                        out.mesh->verts_[newIdx]->edge = nullptr;
                         remap.emplace(v->idx, newIdx);
-                        backMap.push_back(v->idx);
+                        out.vertex_map.push_back(v->idx);
                     }
                 }
             }
 
             // Clone each face into the sub-mesh, remapping source vertex
             // indices to the sub-mesh's densified indices. clone_face_
-            // preserves FaceTraits and EdgeTraits.
+            // preserves FaceTraits and EdgeTraits. Face indices in the sub-
+            // mesh come out densified in insertion order, so the loop's idx
+            // matches the sub-face idx and we can record face_map alongside.
             const auto remapFn = [&remap](std::size_t i) { return remap.at(i); };
             for (const auto& face : component) {
-                sub->clone_face_(face, remapFn);
+                out.mesh->clone_face_(face, remapFn);
+                out.face_map.push_back(face->idx);
             }
-            sub->update_boundary();
+            out.mesh->update_boundary();
 
-            result.emplace_back(std::move(sub), std::move(backMap));
+            result.push_back(std::move(out));
         }
         return result;
     }

--- a/single_include/OpenABF/OpenABF.hpp
+++ b/single_include/OpenABF/OpenABF.hpp
@@ -1695,26 +1695,44 @@ public:
     }
 
     /**
+     * @brief One element of `extract_connected_components()`'s output.
+     *
+     * Holds an extracted sub-mesh and the two index maps callers need to
+     * relate sub-mesh elements back to the source mesh. The mapping is 1-to-1
+     * in both directions for a manifold input — every source vertex/face is
+     * in exactly one component.
+     */
+    struct ExtractedComponent {
+        /** Deep copy of the connected component as an independent mesh. */
+        Pointer mesh;
+        /** `vertex_map[sub_idx] == original_idx`. */
+        std::vector<std::size_t> vertex_map;
+        /** `face_map[sub_idx] == original_idx`. */
+        std::vector<std::size_t> face_map;
+    };
+
+    /**
      * @brief Extract each connected component of this mesh into its own
      * independent mesh.
      *
-     * Returns one `(extracted_mesh, back_map)` pair per connected component.
-     * The extracted meshes are deep copies that preserve VertexTraits,
-     * EdgeTraits, and FaceTraits via the relevant copy constructors. Vertex
-     * indices in the extracted meshes are re-densified to `0..N-1` and
-     * `back_map[extracted_idx] == original_idx` lets callers scatter
-     * per-vertex results from the sub-mesh back onto the source.
+     * Returns one `ExtractedComponent` per connected component. The extracted
+     * meshes are deep copies that preserve VertexTraits, EdgeTraits, and
+     * FaceTraits via the relevant copy constructors. Vertex and face indices
+     * in the extracted meshes are re-densified to `0..N-1`; the `vertex_map`
+     * and `face_map` let callers scatter/gather per-vertex and per-face data
+     * between the sub-mesh and the source.
      *
      * A single-component mesh produces a vector of length 1 whose extracted
-     * mesh is equivalent to `clone()` and whose back-map is the identity.
+     * mesh is equivalent to `clone()` and whose maps are both the identity.
      */
-    auto extract_connected_components() -> std::vector<std::pair<Pointer, std::vector<std::size_t>>>
+    auto extract_connected_components() -> std::vector<ExtractedComponent>
     {
-        std::vector<std::pair<Pointer, std::vector<std::size_t>>> result;
+        std::vector<ExtractedComponent> result;
         for (const auto& component : connected_components()) {
-            auto sub = HalfEdgeMesh::New();
+            ExtractedComponent out;
+            out.mesh = HalfEdgeMesh::New();
             std::unordered_map<std::size_t, std::size_t> remap;
-            std::vector<std::size_t> backMap;
+            out.face_map.reserve(component.size());
 
             // Insert vertices first so the sub-mesh has the targets that
             // clone_face_ will look up via verts_.at(...). Copy ctor here
@@ -1723,24 +1741,27 @@ public:
                 for (const auto& edge : *face) {
                     const auto& v = edge->vertex;
                     if (remap.find(v->idx) == remap.end()) {
-                        const auto newIdx = sub->insert_vertex(*v);
-                        sub->verts_[newIdx]->edge = nullptr;
+                        const auto newIdx = out.mesh->insert_vertex(*v);
+                        out.mesh->verts_[newIdx]->edge = nullptr;
                         remap.emplace(v->idx, newIdx);
-                        backMap.push_back(v->idx);
+                        out.vertex_map.push_back(v->idx);
                     }
                 }
             }
 
             // Clone each face into the sub-mesh, remapping source vertex
             // indices to the sub-mesh's densified indices. clone_face_
-            // preserves FaceTraits and EdgeTraits.
+            // preserves FaceTraits and EdgeTraits. Face indices in the sub-
+            // mesh come out densified in insertion order, so the loop's idx
+            // matches the sub-face idx and we can record face_map alongside.
             const auto remapFn = [&remap](std::size_t i) { return remap.at(i); };
             for (const auto& face : component) {
-                sub->clone_face_(face, remapFn);
+                out.mesh->clone_face_(face, remapFn);
+                out.face_map.push_back(face->idx);
             }
-            sub->update_boundary();
+            out.mesh->update_boundary();
 
-            result.emplace_back(std::move(sub), std::move(backMap));
+            result.push_back(std::move(out));
         }
         return result;
     }

--- a/tests/src/TestHalfEdgeMesh.cpp
+++ b/tests/src/TestHalfEdgeMesh.cpp
@@ -538,8 +538,8 @@ TEST(HalfEdgeMesh, Clone)
 TEST(HalfEdgeMesh, ExtractConnectedComponentsSingleCCPassthrough)
 {
     // Single-CC mesh: extract_connected_components returns one element whose
-    // geometry and connectivity match the source and whose back-map is the
-    // identity over [0, N).
+    // geometry and connectivity match the source and whose vertex/face maps
+    // are both the identity over [0, N).
     auto mesh = MeshType::New();
     mesh->insert_vertices({{0.f, 0.f, 0.f}, {1.f, 0.f, 0.f}, {0.f, 1.f, 0.f}});
     mesh->insert_faces({{0, 1, 2}});
@@ -547,20 +547,22 @@ TEST(HalfEdgeMesh, ExtractConnectedComponentsSingleCCPassthrough)
     auto components = mesh->extract_connected_components();
     ASSERT_EQ(components.size(), 1u);
 
-    const auto& [sub, backMap] = components[0];
-    EXPECT_EQ(sub->num_vertices(), 3u);
-    EXPECT_EQ(sub->num_faces(), 1u);
-    EXPECT_EQ(backMap, (std::vector<std::size_t>{0, 1, 2}));
+    const auto& cc = components[0];
+    EXPECT_EQ(cc.mesh->num_vertices(), 3u);
+    EXPECT_EQ(cc.mesh->num_faces(), 1u);
+    EXPECT_EQ(cc.vertex_map, (std::vector<std::size_t>{0, 1, 2}));
+    EXPECT_EQ(cc.face_map, (std::vector<std::size_t>{0}));
 
-    for (std::size_t i = 0; i < sub->num_vertices(); ++i) {
-        EXPECT_EQ(sub->vertex(i)->pos, mesh->vertex(backMap[i])->pos);
+    for (std::size_t i = 0; i < cc.mesh->num_vertices(); ++i) {
+        EXPECT_EQ(cc.mesh->vertex(i)->pos, mesh->vertex(cc.vertex_map[i])->pos);
     }
 }
 
 TEST(HalfEdgeMesh, ExtractConnectedComponentsTwoCCs)
 {
-    // Two disjoint triangles -> two extracted meshes with disjoint back-maps
-    // covering every original vertex exactly once.
+    // Two disjoint triangles -> two extracted meshes with disjoint vertex
+    // maps covering every original vertex exactly once, and face maps
+    // pointing back to the source face indices.
     auto mesh = MeshType::New();
     mesh->insert_vertices({
         {0.f, 0.f, 0.f},
@@ -577,19 +579,24 @@ TEST(HalfEdgeMesh, ExtractConnectedComponentsTwoCCs)
     ASSERT_EQ(components.size(), 2u);
 
     std::vector<std::size_t> originalsCovered;
-    for (const auto& [sub, backMap] : components) {
-        EXPECT_EQ(sub->num_vertices(), 3u);
-        EXPECT_EQ(sub->num_faces(), 1u);
+    std::vector<std::size_t> facesCovered;
+    for (const auto& cc : components) {
+        EXPECT_EQ(cc.mesh->num_vertices(), 3u);
+        EXPECT_EQ(cc.mesh->num_faces(), 1u);
+        ASSERT_EQ(cc.face_map.size(), 1u);
+        facesCovered.push_back(cc.face_map[0]);
 
-        for (std::size_t i = 0; i < sub->num_vertices(); ++i) {
-            EXPECT_EQ(sub->vertex(i)->idx, i);
-            EXPECT_EQ(sub->vertex(i)->pos, mesh->vertex(backMap[i])->pos);
-            originalsCovered.push_back(backMap[i]);
+        for (std::size_t i = 0; i < cc.mesh->num_vertices(); ++i) {
+            EXPECT_EQ(cc.mesh->vertex(i)->idx, i);
+            EXPECT_EQ(cc.mesh->vertex(i)->pos, mesh->vertex(cc.vertex_map[i])->pos);
+            originalsCovered.push_back(cc.vertex_map[i]);
         }
     }
 
     std::sort(originalsCovered.begin(), originalsCovered.end());
     EXPECT_EQ(originalsCovered, (std::vector<std::size_t>{0, 1, 2, 3, 4, 5}));
+    std::sort(facesCovered.begin(), facesCovered.end());
+    EXPECT_EQ(facesCovered, (std::vector<std::size_t>{0, 1}));
 }
 
 namespace
@@ -641,7 +648,7 @@ TEST(HalfEdgeMesh, ExtractPreservesCustomEdgeTraits)
     ASSERT_EQ(components.size(), 2u);
 
     for (std::size_t c = 0; c < components.size(); ++c) {
-        auto& sub = components[c].first;
+        auto& sub = components[c].mesh;
         ASSERT_EQ(sub->num_faces(), 1u);
         std::vector<int> subLabels;
         for (const auto& e : *sub->face(0)) {
@@ -650,4 +657,59 @@ TEST(HalfEdgeMesh, ExtractPreservesCustomEdgeTraits)
         EXPECT_EQ(subLabels, srcLabels[c])
             << "edge labels not preserved on extracted component " << c;
     }
+}
+
+TEST(HalfEdgeMesh, ExtractFaceMapAfterSplit)
+{
+    // Realistic case: 3x3 grid torn down the middle. Extracted face_maps
+    // partition the source face indices [0, num_faces) without overlap.
+    auto mesh = MeshType::New();
+    mesh->insert_vertices({
+        {0.f, 0.f, 0.f},
+        {1.f, 0.f, 0.f},
+        {2.f, 0.f, 0.f},
+        {0.f, 1.f, 0.f},
+        {1.f, 1.f, 0.f},
+        {2.f, 1.f, 0.f},
+        {0.f, 2.f, 0.f},
+        {1.f, 2.f, 0.f},
+        {2.f, 2.f, 0.f},
+    });
+    mesh->insert_faces({
+        {0, 3, 1},
+        {1, 3, 4},
+        {1, 4, 2},
+        {2, 4, 5},
+        {3, 6, 4},
+        {4, 6, 7},
+        {4, 7, 5},
+        {5, 7, 8},
+    });
+    mesh->split_path({1, 4});
+    mesh->split_path({4, 7});
+    ASSERT_EQ(mesh->num_connected_components(), 2u);
+
+    auto components = mesh->extract_connected_components();
+    ASSERT_EQ(components.size(), 2u);
+
+    std::vector<std::size_t> allFaces;
+    for (const auto& cc : components) {
+        EXPECT_EQ(cc.face_map.size(), cc.mesh->num_faces());
+        for (std::size_t i = 0; i < cc.mesh->num_faces(); ++i) {
+            // Vertex positions on the extracted face match the source face
+            // they map back to.
+            auto srcFace = mesh->face(cc.face_map[i]);
+            auto srcIt = srcFace->begin();
+            auto subIt = cc.mesh->face(i)->begin();
+            while (srcIt != srcFace->end()) {
+                EXPECT_EQ((*srcIt)->vertex->pos, (*subIt)->vertex->pos);
+                ++srcIt;
+                ++subIt;
+            }
+            allFaces.push_back(cc.face_map[i]);
+        }
+    }
+
+    std::sort(allFaces.begin(), allFaces.end());
+    EXPECT_EQ(allFaces, (std::vector<std::size_t>{0, 1, 2, 3, 4, 5, 6, 7}));
 }


### PR DESCRIPTION
Follow-up to #80. `HalfEdgeMesh::extract_connected_components()` previously returned only a vertex back-map, which is insufficient for any per-face downstream work — per-face attribute scatter/gather, wedge UV tables for mesh IO, etc. all need to know which source face each extracted face came from.

## API change (breaking)

```cpp
struct HalfEdgeMesh::ExtractedComponent {
    Pointer mesh;
    std::vector<std::size_t> vertex_map;  // [sub_idx] -> original_idx
    std::vector<std::size_t> face_map;    // [sub_idx] -> original_idx
};
std::vector<ExtractedComponent> extract_connected_components();
```

`face_map` is captured during the existing `clone_face_` loop — `clone_face_` returns the new face's densified idx (via `insert_face_`), which is exactly the order we push to `face_map`. Zero runtime cost added.

The named struct also keeps the API extensible for future provenance maps (edge, half-edge, etc.) without further breaking changes.

## Call-site impact

Only in-tree caller is `examples/src/MultiChartFlatten.cpp`. Updated from `auto& [chart, backMap] = charts[i]` to `auto& cc = charts[i]` with `cc.mesh` / `cc.vertex_map` / `cc.face_map`.

## Test plan
- [x] Existing `ExtractConnectedComponentsSingleCCPassthrough` updated — `vertex_map` and `face_map` are both identity `[0..N)`.
- [x] Existing `ExtractConnectedComponentsTwoCCs` updated — verifies both maps partition the source's vertex and face indices.
- [x] New `ExtractFaceMapAfterSplit` — realistic post-split case (3x3 grid torn down the middle), face_maps partition the source's 8 face indices and per-corner positions on the extracted face match the source face it maps back to.
- [x] `ExtractPreservesCustomEdgeTraits` updated for the new access pattern.
- [x] All 6 ctest suites pass.
- [x] `openabf_example_multi_chart_flatten` builds and runs end-to-end.
- [x] `single_include/OpenABF/OpenABF.hpp` regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)