### PR TITLE
test(hlscm): assert pinned vertex UVs in setPinnedVertices test (T6)

### DIFF
--- a/conductor/tracks.md
+++ b/conductor/tracks.md
@@ -12,7 +12,6 @@
 | open | P6 | Precompute sin/cos values before HLSCM face assembly loop | [#66](https://github.com/educelab/OpenABF/issues/66) | 2026-03-20 | 2026-03-20 |
 | open | A9 | Mark detail::hlscm types with @internal Doxygen tag | [#67](https://github.com/educelab/OpenABF/issues/67) | 2026-03-20 | 2026-03-20 |
 | open | A10 | Add static Compute() overloads accepting levelRatio and minCoarseVertices | [#68](https://github.com/educelab/OpenABF/issues/68) | 2026-03-20 | 2026-03-20 |
-| open | T6 | Add test for HLSCM::setPinnedVertices() instance API | [#51](https://github.com/educelab/OpenABF/issues/51) | 2026-03-20 | 2026-03-20 |
 | open | T7 | ABFPlusPlusAnglePreservation may be vacuous on flat wavy mesh | [#50](https://github.com/educelab/OpenABF/issues/50) | 2026-03-20 | 2026-03-20 |
 | open | E2 | Add sphere cap built-in mesh generator to benchmark | [#48](https://github.com/educelab/OpenABF/issues/48) | 2026-03-20 | 2026-03-20 |
 | open | F5 | Implement Hierarchical SLIM (H-SLIM) | [#52](https://github.com/educelab/OpenABF/issues/52) | 2026-03-20 | 2026-03-20 |
@@ -28,6 +27,7 @@
 
 | Status | Track ID | Title | GitHub | Archived |
 | ------ | -------- | ----- | ------ | -------- |
+| closed | T6 | Add test for HLSCM::setPinnedVertices() instance API | [#51](https://github.com/educelab/OpenABF/issues/51) | 2026-06-12 |
 | closed | T8 | Strengthen InstanceAPILevelRatio to verify parameters are applied | [#49](https://github.com/educelab/OpenABF/issues/49) | 2026-06-12 |
 | closed | F3 | Multi-component extraction and parameterization pipeline (PRs #80, #81; ParameterizeConnectedComponents descoped) | [#19](https://github.com/educelab/OpenABF/issues/19) | 2026-06-12 |
 | closed | M5 | split_edge and detail::filter cleanup (PR #79) | [#76](https://github.com/educelab/OpenABF/issues/76), [#77](https://github.com/educelab/OpenABF/issues/77), [#78](https://github.com/educelab/OpenABF/issues/78) | 2026-06-12 |

--- a/conductor/tracks/T6/plan.md
+++ b/conductor/tracks/T6/plan.md
@@ -1,9 +1,9 @@
 # T6 Implementation Plan
 
 ## Phase 1: Test Implementation
-- [ ] 1.1 Create test mesh suitable for pin verification
-- [ ] 1.2 Write test calling setPinnedVertices() and Compute()
-- [ ] 1.3 Assert pinned vertex positions in UV output
+- [x] 1.1 Create test mesh suitable for pin verification
+- [x] 1.2 Write test calling setPinnedVertices() and Compute()
+- [x] 1.3 Assert pinned vertex positions in UV output
 
 ## Phase 2: Verification
-- [ ] 2.1 Run full test suite
+- [x] 2.1 Run full test suite

--- a/tests/src/TestParameterization.cpp
+++ b/tests/src/TestParameterization.cpp
@@ -362,11 +362,40 @@ TEST(HLSCM, SetPinnedVertices)
     hlscm.setPinnedVertices(0, 1);
     hlscm.compute(mesh_instance);
 
+    // Instance API must produce identical output to the static overload
     for (std::size_t v = 0; v < mesh_static->num_vertices(); ++v) {
         for (auto i = 0; i < 3; i++) {
             EXPECT_FLOAT_EQ(mesh_instance->vertex(v)->pos[i], mesh_static->vertex(v)->pos[i]);
         }
     }
+
+    // Pinned vertices must land at their expected UV positions exactly.
+    // HLSCM uses the same pin-placement logic as AngleBasedLSCM: pin0 at the
+    // origin and pin1 at distance |p1-p0| along the dominant world-space axis
+    // of the (p1-p0) vector. For ConstructPyramid with pins (0, 1) this places
+    // pin0 at {0, 0, 0} and pin1 at {2, 0, 0}.
+    const Vec3f expectedPin0{0, 0, 0};
+    const Vec3f expectedPin1{2, 0, 0};
+    for (auto i = 0; i < 3; i++) {
+        EXPECT_FLOAT_EQ(mesh_instance->vertex(0)->pos[i], expectedPin0[i]);
+        EXPECT_FLOAT_EQ(mesh_instance->vertex(1)->pos[i], expectedPin1[i]);
+    }
+
+    // Sanity check: pinning must actually be applied. Non-pinned vertices must
+    // not all collapse onto the pin positions.
+    bool anyNonPinnedDiffers = false;
+    for (std::size_t v = 2; v < mesh_instance->num_vertices(); ++v) {
+        const auto& p = mesh_instance->vertex(v)->pos;
+        const bool atPin0 =
+            (p[0] == expectedPin0[0]) && (p[1] == expectedPin0[1]) && (p[2] == expectedPin0[2]);
+        const bool atPin1 =
+            (p[0] == expectedPin1[0]) && (p[1] == expectedPin1[1]) && (p[2] == expectedPin1[2]);
+        if (!atPin0 && !atPin1) {
+            anyNonPinnedDiffers = true;
+            break;
+        }
+    }
+    EXPECT_TRUE(anyNonPinnedDiffers);
 }
 
 TEST(HLSCM, Double)


### PR DESCRIPTION
## Summary
- Strengthens `TEST(HLSCM, SetPinnedVertices)` to directly assert pinned vertex UV positions instead of only asserting equivalence with the static API.
- Adds a sanity check that non-pinned vertices differ from the pin positions.

## Test plan
- [x] `ctest` passes

Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)