### PR TITLE
test(hlscm): use curved mesh for ABFPlusPlusAnglePreservation (T7)

### DIFF
--- a/conductor/tracks.md
+++ b/conductor/tracks.md
@@ -11,7 +11,6 @@
 | open | T5 | HLSCM internal component unit tests (buildHierarchy, prolongateUVs, solveLSCMLevel) | [#65](https://github.com/educelab/OpenABF/issues/65) | 2026-03-20 | 2026-03-20 |
 | open | P6 | Precompute sin/cos values before HLSCM face assembly loop | [#66](https://github.com/educelab/OpenABF/issues/66) | 2026-03-20 | 2026-03-20 |
 | open | A10 | Add static Compute() overloads accepting levelRatio and minCoarseVertices | [#68](https://github.com/educelab/OpenABF/issues/68) | 2026-03-20 | 2026-03-20 |
-| open | T7 | ABFPlusPlusAnglePreservation may be vacuous on flat wavy mesh | [#50](https://github.com/educelab/OpenABF/issues/50) | 2026-03-20 | 2026-03-20 |
 | open | E2 | Add sphere cap built-in mesh generator to benchmark | [#48](https://github.com/educelab/OpenABF/issues/48) | 2026-03-20 | 2026-03-20 |
 | open | F5 | Implement Hierarchical SLIM (H-SLIM) | [#52](https://github.com/educelab/OpenABF/issues/52) | 2026-03-20 | 2026-03-20 |
 | open | F6 | Migrate to C++20 | [#54](https://github.com/educelab/OpenABF/issues/54) | 2026-03-20 | 2026-03-20 |
@@ -26,6 +25,7 @@
 
 | Status | Track ID | Title | GitHub | Archived |
 | ------ | -------- | ----- | ------ | -------- |
+| closed | T7 | ABFPlusPlusAnglePreservation now uses curved mesh (hemisphere) for meaningful ABF exercise | [#50](https://github.com/educelab/OpenABF/issues/50) | 2026-06-12 |
 | closed | A9 | Mark detail::hlscm types with @internal Doxygen tag | [#67](https://github.com/educelab/OpenABF/issues/67) | 2026-06-12 |
 | closed | T6 | Add test for HLSCM::setPinnedVertices() instance API | [#51](https://github.com/educelab/OpenABF/issues/51) | 2026-06-12 |
 | closed | T8 | Strengthen InstanceAPILevelRatio to verify parameters are applied | [#49](https://github.com/educelab/OpenABF/issues/49) | 2026-06-12 |

--- a/conductor/tracks/T7/plan.md
+++ b/conductor/tracks/T7/plan.md
@@ -1,12 +1,25 @@
 # T7 Implementation Plan
 
 ## Phase 1: Investigation
-- [ ] 1.1 Review ABFPlusPlusAnglePreservation test
-- [ ] 1.2 Determine if it passes vacuously on flat mesh
+- [x] 1.1 Review ABFPlusPlusAnglePreservation test
+- [x] 1.2 Determine if it passes vacuously on flat mesh
+  - Wavy mesh (z = 0.3·sin·cos) produced UV maxDiff ≈ 0.057, L2 ≈ 0.62
+    between ABF→HLSCM and geometry-only HLSCM. Non-zero, but weak — a regression
+    that discarded ABF angles would only drop a small signal, and the existing
+    `> 1e-6f` threshold could be tripped by unrelated numerical noise.
+  - Test was not strictly vacuous, but the signal-to-noise ratio was poor.
 
 ## Phase 2: Fix
-- [ ] 2.1 Create or source a curved test mesh
-- [ ] 2.2 Update test to use curved mesh with meaningful angle assertions
+- [x] 2.1 Switch test to curved mesh
+  - Replaced `ConstructWavySurface<…>(20, 20)` with
+    `ConstructHemisphere<…>(12, 24)`. The hemisphere has genuine Gaussian
+    curvature so ABF angle correction has real work to do.
+- [x] 2.2 Tighten assertions
+  - Snapshot raw geometry angles before `ABFType::Compute`, then assert
+    `maxAngleDelta > 1e-3f` to prove ABF actually changed the input.
+  - Assert UV `maxDiff > 1e-2f` (vs original `> 1e-6f`). On the hemisphere
+    observed maxDiff ≈ 1.03 and L2 ≈ 9.08 — orders of magnitude above the
+    threshold, but a regression that discards ABF angles drops both to ~0.
 
 ## Phase 3: Verification
-- [ ] 3.1 Run full test suite
+- [x] 3.1 Run full test suite — all 6 ctest suites pass.

--- a/tests/src/TestParameterization.cpp
+++ b/tests/src/TestParameterization.cpp
@@ -561,22 +561,57 @@ TEST(HLSCM, ABFPlusPlusAnglePreservation)
     // hierarchy level by checking that the result differs from geometry-only
     // HLSCM.  If angles were being discarded (recomputed from geometry), both
     // would produce identical output.
+    //
+    // Uses a hemisphere (genuine Gaussian curvature) so ABF angle correction
+    // has meaningful work to do.  On a near-flat mesh (e.g. wavy surface) the
+    // ABF correction is small, so the UV deltas are also small and the test
+    // is weak; a hemisphere guarantees a strong, easy-to-detect signal.
     using ABFType = ABFPlusPlus<float>;
     using HLSCM_ABF = HierarchicalLSCM<float, ABFType::Mesh>;
     using HLSCM_Geo = HierarchicalLSCM<float>;
 
-    constexpr std::size_t N = 20;
+    constexpr std::size_t rings = 12;
+    constexpr std::size_t sectors = 24;
+
+    // Snapshot the raw geometry angles before ABF rewrites them so we can
+    // verify ABF actually altered the angles (i.e. its output is non-trivial).
+    auto saveAngles = [](const auto& mesh) {
+        std::unordered_map<std::size_t, float> angles;
+        for (const auto& f : mesh->faces()) {
+            for (auto& e : *f) {
+                angles[e->idx] = e->alpha;
+            }
+        }
+        return angles;
+    };
 
     // HLSCM with ABF-optimized angles
-    auto mesh_abf = ConstructWavySurface<ABFType::Mesh>(N, N);
+    auto mesh_abf = ConstructHemisphere<ABFType::Mesh>(rings, sectors);
+    auto rawAngles = saveAngles(mesh_abf);
     ABFType::Compute(mesh_abf);
+
+    // Confirm ABF actually changed the per-half-edge angles before HLSCM runs.
+    // Without this, an "anyDifference" check downstream could be triggered by
+    // unrelated noise (solver tolerances, etc.).
+    float maxAngleDelta = 0.f;
+    for (const auto& f : mesh_abf->faces()) {
+        for (auto& e : *f) {
+            maxAngleDelta = std::max(maxAngleDelta, std::abs(e->alpha - rawAngles.at(e->idx)));
+        }
+    }
+    EXPECT_GT(maxAngleDelta, 1e-3f)
+        << "ABF++ did not modify input angles meaningfully on the curved mesh "
+           "(maxAngleDelta="
+        << maxAngleDelta << ")";
+
     HLSCM_ABF::Compute(mesh_abf);
 
     // HLSCM with geometry-only angles (no ABF)
-    auto mesh_geo = ConstructWavySurface<HLSCM_Geo::Mesh>(N, N);
+    auto mesh_geo = ConstructHemisphere<HLSCM_Geo::Mesh>(rings, sectors);
     HLSCM_Geo::Compute(mesh_geo);
 
     // Both must produce valid UVs
+    ASSERT_EQ(mesh_abf->num_vertices(), mesh_geo->num_vertices());
     for (std::size_t v = 0; v < mesh_abf->num_vertices(); ++v) {
         const auto& pos = mesh_abf->vertex(v)->pos;
         EXPECT_TRUE(std::isfinite(pos[0])) << "vertex " << v;
@@ -584,22 +619,25 @@ TEST(HLSCM, ABFPlusPlusAnglePreservation)
         EXPECT_FLOAT_EQ(pos[2], 0.f);
     }
 
-    // The ABF-optimized angles should produce a measurably different result
-    // from geometry angles, proving they are actually being used at the
-    // finest level.
-    bool anyDifference = false;
+    // Measure UV difference between the two parameterizations.  Because the
+    // two solves are independent (different boundary pins resolve to the same
+    // similarity class but not the same exact coordinates), we look at the
+    // per-vertex maximum delta and require it to be substantially larger than
+    // numerical noise.  On a hemisphere the signal is order 0.1+ in UV units;
+    // a regression that discards ABF angles drops this to ~0.
+    float maxDiff = 0.f;
+    double l2Diff = 0.0;
     for (std::size_t v = 0; v < mesh_abf->num_vertices(); ++v) {
         for (int i = 0; i < 2; ++i) {
-            if (std::abs(mesh_abf->vertex(v)->pos[i] - mesh_geo->vertex(v)->pos[i]) > 1e-6f) {
-                anyDifference = true;
-                break;
-            }
+            float d = std::abs(mesh_abf->vertex(v)->pos[i] - mesh_geo->vertex(v)->pos[i]);
+            maxDiff = std::max(maxDiff, d);
+            l2Diff += static_cast<double>(d) * static_cast<double>(d);
         }
-        if (anyDifference)
-            break;
     }
-    EXPECT_TRUE(anyDifference) << "ABF++ angles had no effect on HLSCM output — "
-                                  "angles may not be preserved at finest hierarchy level";
+    EXPECT_GT(maxDiff, 1e-2f) << "ABF++ angles had negligible effect on HLSCM output "
+                                 "(maxDiff="
+                              << maxDiff << ", L2=" << std::sqrt(l2Diff)
+                              << ") — angles may not be preserved at finest hierarchy level";
 }
 
 TEST(HLSCM, ABFReducesConformalDistortion)


### PR DESCRIPTION
## Summary
- Replaces the flat wavy-mesh fixture in `TEST(HLSCM, ABFPlusPlusAnglePreservation)` with a hemisphere so the test meaningfully exercises ABF angle correction.
- Adds an explicit pre-check that ABF actually altered the per-half-edge angles (snapshot before `ABFType::Compute`, assert `maxAngleDelta > 1e-3f`).
- Raises the UV-difference threshold from `> 1e-6f` (noise-level) to `> 1e-2f`, well within the new signal's safety margin.

## Investigation
On the original wavy mesh, ABF-vs-geometry HLSCM produced UV `maxDiff ~0.057, L2 ~0.62` — not strictly vacuous, but a weak signal barely above numerical noise. On the hemisphere the signal jumps to `maxDiff ~1.03, L2 ~9.08` with ABF angle delta ~0.13 rad, so a regression that discards ABF angles now collapses both to ~0 and fails clearly.

## Test plan
- [x] `ctest --output-on-failure` passes (6/6 suites, 18/18 HLSCM tests)

Closes #50

Generated with Claude Code