### PR TITLE
chore: sync index.md status for closed Conductor tracks

### DIFF
--- a/conductor/tracks/T5/index.md
+++ b/conductor/tracks/T5/index.md
@@ -1,6 +1,6 @@
 # T5 — HLSCM internal component unit tests
 
-**Status:** open
+**Status:** closed
 **Issue:** https://github.com/educelab/OpenABF/issues/65
 **Dependencies:** F1
 


### PR DESCRIPTION
## Summary

The `/conductor:manage archive` workflow updates `conductor/tracks.md` but does not propagate `Status:` changes into per-track `index.md` files. Walked the tracks tree and synced any closed-in-registry tracks whose `index.md` still said `open`.

## Tracks touched

- **T5** (`conductor/tracks/T5/index.md`): `open` -> `closed`

Other recently-closed tracks (E2, T7, A9, T6, T8, F3) have no `index.md`, so nothing to update there. A8 and E1 were already correctly marked.

## Test plan

- [x] `git diff` shows only `Status:` line changes in `index.md` files
- [x] No registry / spec / plan / Conductor metadata changes

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>