### PR TITLE
docs: clear remaining Doxygen warnings

### DIFF
--- a/include/OpenABF/AngleBasedLSCM.hpp
+++ b/include/OpenABF/AngleBasedLSCM.hpp
@@ -155,6 +155,8 @@ public:
     /**
      * @brief Compute the parameterized mesh with explicit pinned vertex indices
      *
+     * @param mesh Triangle mesh whose vertex positions will be overwritten with
+     * computed 2D UV coordinates (z component set to 0).
      * @param pin0Idx Index of the first pinned vertex (placed at the UV origin)
      * @param pin1Idx Index of the second pinned vertex (placed on the nearest axis)
      * @throws SolverException If matrix cannot be decomposed or if solver fails

--- a/include/OpenABF/HalfEdgeMesh.hpp
+++ b/include/OpenABF/HalfEdgeMesh.hpp
@@ -76,14 +76,18 @@ auto remove_if(ForwardContainer v, UnaryPred p)
  */
 template <typename Iter>
 struct Range {
-    /// \cond INTERNAL
+    /** First iterator in the range. */
     Iter first_;
+    /** One-past-last iterator in the range. */
     Iter last_;
+    /** Range begin iterator. */
     auto begin() const -> Iter { return first_; }
+    /** Range end iterator. */
     auto end() const -> Iter { return last_; }
+    /** True if the range is empty. */
     auto empty() const -> bool { return first_ == last_; }
+    /** First element of the range. */
     auto front() const -> decltype(*first_) { return *first_; }
-    /// \endcond
 };
 
 /**
@@ -96,22 +100,31 @@ template <typename Iter, typename Pred>
 class FilteringIterator
 {
 public:
-    /// \cond INTERNAL
+    /** Difference type. */
     using difference_type = std::ptrdiff_t;
+    /** Value type. */
     using value_type = typename std::iterator_traits<Iter>::value_type;
+    /** Pointer type. */
     using pointer = typename std::iterator_traits<Iter>::pointer;
+    /** Reference type. */
     using reference = typename std::iterator_traits<Iter>::reference;
+    /** Iterator category. */
     using iterator_category = std::input_iterator_tag;
 
+    /** Default constructor. */
     FilteringIterator() = default;
+    /** Construct over `[current, end)` filtering by `pred`. */
     FilteringIterator(Iter current, Iter end, Pred pred) : current_{current}, end_{end}, pred_{pred}
     {
         advance_to_next();
     }
 
+    /** Dereference. */
     auto operator*() const -> reference { return *current_; }
+    /** Member access. */
     auto operator->() const -> pointer { return &*current_; }
 
+    /** Pre-increment; skips elements failing `pred`. */
     auto operator++() -> FilteringIterator&
     {
         ++current_;
@@ -119,15 +132,16 @@ public:
         return *this;
     }
 
+    /** Equality. */
     auto operator==(const FilteringIterator& other) const -> bool
     {
         return current_ == other.current_;
     }
+    /** Inequality. */
     auto operator!=(const FilteringIterator& other) const -> bool { return !(*this == other); }
-    /// \endcond
 
 private:
-    /// \cond INTERNAL
+    /** Advance `current_` past elements failing `pred_`. */
     void advance_to_next()
     {
         while (current_ != end_ && !pred_(*current_)) {
@@ -135,10 +149,12 @@ private:
         }
     }
 
+    /** Underlying iterator position. */
     Iter current_{};
+    /** Underlying end iterator. */
     Iter end_{};
+    /** Predicate selecting which elements to visit. */
     Pred pred_{};
-    /// \endcond
 };
 }  // namespace detail
 
@@ -526,7 +542,7 @@ private:
         }
 
     private:
-        /// \cond INTERNAL
+        /** Advance `current_` past boundary edges, wrapping to `nullptr` at end. */
         void advance_to_non_boundary()
         {
             while (current_ && current_->is_boundary()) {
@@ -538,9 +554,10 @@ private:
             }
         }
 
+        /** First edge in the wheel (used to detect wrap-around). */
         EdgePtr head_{};
+        /** Current edge in the wheel; `nullptr` at end. */
         EdgePtr current_{};
-        /// \endcond
     };
 
     /**
@@ -616,7 +633,7 @@ private:
         }
 
     private:
-        /// \cond INTERNAL
+        /** Advance `faceIt_` until a face with remaining edges is found, or the end is reached. */
         void advance_if_face_exhausted()
         {
             while (edgeIt_ == FaceIterator<true>() && faceIt_ != faceEnd_) {
@@ -627,10 +644,12 @@ private:
             }
         }
 
+        /** Current position in the face vector. */
         FaceVecIter faceIt_{};
+        /** End of the face vector. */
         FaceVecIter faceEnd_{};
+        /** Edge iterator within the current face. */
         FaceIterator<true> edgeIt_{};
-        /// \endcond
     };
 
 public:

--- a/include/OpenABF/HalfEdgeMesh.hpp
+++ b/include/OpenABF/HalfEdgeMesh.hpp
@@ -76,12 +76,14 @@ auto remove_if(ForwardContainer v, UnaryPred p)
  */
 template <typename Iter>
 struct Range {
+    /// \cond INTERNAL
     Iter first_;
     Iter last_;
     auto begin() const -> Iter { return first_; }
     auto end() const -> Iter { return last_; }
     auto empty() const -> bool { return first_ == last_; }
     auto front() const -> decltype(*first_) { return *first_; }
+    /// \endcond
 };
 
 /**
@@ -94,6 +96,7 @@ template <typename Iter, typename Pred>
 class FilteringIterator
 {
 public:
+    /// \cond INTERNAL
     using difference_type = std::ptrdiff_t;
     using value_type = typename std::iterator_traits<Iter>::value_type;
     using pointer = typename std::iterator_traits<Iter>::pointer;
@@ -121,8 +124,10 @@ public:
         return current_ == other.current_;
     }
     auto operator!=(const FilteringIterator& other) const -> bool { return !(*this == other); }
+    /// \endcond
 
 private:
+    /// \cond INTERNAL
     void advance_to_next()
     {
         while (current_ != end_ && !pred_(*current_)) {
@@ -133,6 +138,7 @@ private:
     Iter current_{};
     Iter end_{};
     Pred pred_{};
+    /// \endcond
 };
 }  // namespace detail
 
@@ -483,12 +489,13 @@ private:
             advance_to_non_boundary();
         }
 
-        /** Dereference */
+        /** Dereference (const overload) */
         template <bool C = Const>
         auto operator*() const -> std::enable_if_t<C, reference>
         {
             return current_;
         }
+        /** Dereference (non-const overload) */
         template <bool C = Const>
         auto operator*() -> std::enable_if_t<!C, reference>
         {
@@ -519,6 +526,7 @@ private:
         }
 
     private:
+        /// \cond INTERNAL
         void advance_to_non_boundary()
         {
             while (current_ && current_->is_boundary()) {
@@ -532,6 +540,7 @@ private:
 
         EdgePtr head_{};
         EdgePtr current_{};
+        /// \endcond
     };
 
     /**
@@ -558,6 +567,7 @@ private:
         /** Iterator category */
         using iterator_category = std::input_iterator_tag;
 
+        /** Underlying face-vector iterator type */
         using FaceVecIter = typename std::vector<FacePtr>::const_iterator;
 
         /** Construct at position (begin or end depending on faceIt == faceEnd) */
@@ -569,12 +579,13 @@ private:
             }
         }
 
-        /** Dereference */
+        /** Dereference (const overload) */
         template <bool C = Const>
         auto operator*() const -> std::enable_if_t<C, reference>
         {
             return *edgeIt_;
         }
+        /** Dereference (non-const overload) */
         template <bool C = Const>
         auto operator*() -> std::enable_if_t<!C, reference>
         {
@@ -605,6 +616,7 @@ private:
         }
 
     private:
+        /// \cond INTERNAL
         void advance_if_face_exhausted()
         {
             while (edgeIt_ == FaceIterator<true>() && faceIt_ != faceEnd_) {
@@ -618,6 +630,7 @@ private:
         FaceVecIter faceIt_{};
         FaceVecIter faceEnd_{};
         FaceIterator<true> edgeIt_{};
+        /// \endcond
     };
 
 public:
@@ -936,7 +949,10 @@ public:
     }
 
     /**
-     * @copydoc insert_vertices(const VectorOfVectors&)
+     * @brief Insert new vertices from a brace-enclosed initializer list
+     *
+     * Convenience overload of insert_vertices() accepting nested
+     * `std::initializer_list` syntax, e.g. `{{0,0,0}, {1,0,0}, {0,1,0}}`.
      */
     template <typename ValType>
     auto insert_vertices(std::initializer_list<std::initializer_list<ValType>> v)

--- a/include/OpenABF/HierarchicalLSCM.hpp
+++ b/include/OpenABF/HierarchicalLSCM.hpp
@@ -469,7 +469,7 @@ public:
     }
 
 private:
-    /// \cond INTERNAL
+    /** Recompute per-vertex QEM quadrics from the live faces (Garland-Heckbert). */
     void computeQuadrics_()
     {
         for (auto& q : quadrics_) {
@@ -505,6 +505,7 @@ private:
         }
     }
 
+    /** Rebuild the unique-edge list from the live faces. */
     void buildEdges_()
     {
         edges_.clear();
@@ -561,26 +562,41 @@ private:
         return {u, v, w};
     }
 
+    /** Per-vertex 3D positions, indexed by original vertex index. */
     std::vector<Vec<T, 3>> positions_;
+    /** Per-vertex alive flag; collapses set entries to false. */
     std::vector<bool> alive_;
+    /** Per-vertex boundary flag, copied from the source mesh. */
     std::vector<bool> isBoundary_;
+    /** Per-vertex pinned flag; pinned vertices cannot be removed by collapse. */
     std::vector<bool> isPinned_;
+    /** Per-vertex QEM quadrics accumulated from incident face planes. */
     std::vector<Quadric<T>> quadrics_;
+    /** Face connectivity: each face is three vertex indices into `positions_`. */
     std::vector<std::array<std::size_t, 3>> faces_;
+    /** Per-face alive flag; collapses retire faces by setting entries to false. */
     std::vector<bool> faceAlive_;
+    /** Per-vertex incident face list. */
     std::vector<std::vector<std::size_t>> vertFaces_;
+    /** Count of alive vertices (kept current across collapses). */
     std::size_t numAliveVerts_{0};
+    /** Count of alive faces (kept current across collapses). */
     std::size_t numAliveFaces_{0};
+    /** Unique-edge list, rebuilt on demand by `buildEdges_()`. */
     std::vector<std::pair<std::size_t, std::size_t>> edges_;
 
-    // Scratch storage reused across tryCollapse calls (avoids repeated heap allocation)
+    /** Scratch buffer: neighbor indices shared between two endpoints. */
     std::vector<std::size_t> scratchShared_;
+    /** Scratch buffer: faces to retire on a collapse. */
     std::vector<std::size_t> scratchRemove_;
+    /** Scratch buffer: post-collapse face rewrites. */
     std::vector<std::array<std::size_t, 3>> scratchPostFaces_;
+    /** Scratch buffer: neighbor list of one endpoint. */
     std::vector<std::size_t> scratchNbrsA_;
+    /** Scratch buffer: neighbor list of the other endpoint. */
     std::vector<std::size_t> scratchNbrsB_;
+    /** Scratch buffer: deduplicated union of `scratchNbrsA_` and `scratchNbrsB_`. */
     std::vector<std::size_t> scratchSharedNbrs_;
-    /// \endcond
 };
 
 /**

--- a/include/OpenABF/HierarchicalLSCM.hpp
+++ b/include/OpenABF/HierarchicalLSCM.hpp
@@ -49,6 +49,7 @@ struct Quadric {
     {
     }
 
+    /** In-place accumulation of another quadric */
     auto operator+=(const Quadric& o) -> Quadric&
     {
         for (std::size_t i = 0; i < 10; ++i) {
@@ -57,6 +58,7 @@ struct Quadric {
         return *this;
     }
 
+    /** Quadric addition */
     friend auto operator+(Quadric a, const Quadric& b) -> Quadric { return a += b; }
 
     /** Evaluate quadric error at point (x, y, z) */
@@ -467,6 +469,7 @@ public:
     }
 
 private:
+    /// \cond INTERNAL
     void computeQuadrics_()
     {
         for (auto& q : quadrics_) {
@@ -577,6 +580,7 @@ private:
     std::vector<std::size_t> scratchNbrsA_;
     std::vector<std::size_t> scratchNbrsB_;
     std::vector<std::size_t> scratchSharedNbrs_;
+    /// \endcond
 };
 
 /**
@@ -1018,6 +1022,12 @@ private:
         }
     }
 
+    /**
+     * @brief Core hierarchical LSCM solve given resolved pin indices
+     *
+     * Builds the mesh hierarchy, solves LSCM at the coarsest level, then
+     * prolongates and refines at each finer level.
+     */
     static void ComputeImpl(typename Mesh::Pointer& mesh, std::size_t pin0Idx, std::size_t pin1Idx,
                             std::size_t levelRatio = 10, std::size_t minCoarseVerts = 100)
     {
@@ -1073,7 +1083,9 @@ private:
 
     /** Optional explicit pin pair */
     std::optional<std::pair<std::size_t, std::size_t>> pinnedVertices_;
+    /** Ratio of vertices between consecutive hierarchy levels */
     std::size_t levelRatio_{10};
+    /** Minimum vertex count for the coarsest hierarchy level */
     std::size_t minCoarseVertices_{100};
 };
 

--- a/single_include/OpenABF/OpenABF.hpp
+++ b/single_include/OpenABF/OpenABF.hpp
@@ -520,12 +520,14 @@ auto remove_if(ForwardContainer v, UnaryPred p)
  */
 template <typename Iter>
 struct Range {
+    /// \cond INTERNAL
     Iter first_;
     Iter last_;
     auto begin() const -> Iter { return first_; }
     auto end() const -> Iter { return last_; }
     auto empty() const -> bool { return first_ == last_; }
     auto front() const -> decltype(*first_) { return *first_; }
+    /// \endcond
 };
 
 /**
@@ -538,6 +540,7 @@ template <typename Iter, typename Pred>
 class FilteringIterator
 {
 public:
+    /// \cond INTERNAL
     using difference_type = std::ptrdiff_t;
     using value_type = typename std::iterator_traits<Iter>::value_type;
     using pointer = typename std::iterator_traits<Iter>::pointer;
@@ -565,8 +568,10 @@ public:
         return current_ == other.current_;
     }
     auto operator!=(const FilteringIterator& other) const -> bool { return !(*this == other); }
+    /// \endcond
 
 private:
+    /// \cond INTERNAL
     void advance_to_next()
     {
         while (current_ != end_ && !pred_(*current_)) {
@@ -577,6 +582,7 @@ private:
     Iter current_{};
     Iter end_{};
     Pred pred_{};
+    /// \endcond
 };
 }  // namespace detail
 
@@ -927,12 +933,13 @@ private:
             advance_to_non_boundary();
         }
 
-        /** Dereference */
+        /** Dereference (const overload) */
         template <bool C = Const>
         auto operator*() const -> std::enable_if_t<C, reference>
         {
             return current_;
         }
+        /** Dereference (non-const overload) */
         template <bool C = Const>
         auto operator*() -> std::enable_if_t<!C, reference>
         {
@@ -963,6 +970,7 @@ private:
         }
 
     private:
+        /// \cond INTERNAL
         void advance_to_non_boundary()
         {
             while (current_ && current_->is_boundary()) {
@@ -976,6 +984,7 @@ private:
 
         EdgePtr head_{};
         EdgePtr current_{};
+        /// \endcond
     };
 
     /**
@@ -1002,6 +1011,7 @@ private:
         /** Iterator category */
         using iterator_category = std::input_iterator_tag;
 
+        /** Underlying face-vector iterator type */
         using FaceVecIter = typename std::vector<FacePtr>::const_iterator;
 
         /** Construct at position (begin or end depending on faceIt == faceEnd) */
@@ -1013,12 +1023,13 @@ private:
             }
         }
 
-        /** Dereference */
+        /** Dereference (const overload) */
         template <bool C = Const>
         auto operator*() const -> std::enable_if_t<C, reference>
         {
             return *edgeIt_;
         }
+        /** Dereference (non-const overload) */
         template <bool C = Const>
         auto operator*() -> std::enable_if_t<!C, reference>
         {
@@ -1049,6 +1060,7 @@ private:
         }
 
     private:
+        /// \cond INTERNAL
         void advance_if_face_exhausted()
         {
             while (edgeIt_ == FaceIterator<true>() && faceIt_ != faceEnd_) {
@@ -1062,6 +1074,7 @@ private:
         FaceVecIter faceIt_{};
         FaceVecIter faceEnd_{};
         FaceIterator<true> edgeIt_{};
+        /// \endcond
     };
 
 public:
@@ -1380,7 +1393,10 @@ public:
     }
 
     /**
-     * @copydoc insert_vertices(const VectorOfVectors&)
+     * @brief Insert new vertices from a brace-enclosed initializer list
+     *
+     * Convenience overload of insert_vertices() accepting nested
+     * `std::initializer_list` syntax, e.g. `{{0,0,0}, {1,0,0}, {0,1,0}}`.
      */
     template <typename ValType>
     auto insert_vertices(std::initializer_list<std::initializer_list<ValType>> v)
@@ -3341,6 +3357,8 @@ public:
     /**
      * @brief Compute the parameterized mesh with explicit pinned vertex indices
      *
+     * @param mesh Triangle mesh whose vertex positions will be overwritten with
+     * computed 2D UV coordinates (z component set to 0).
      * @param pin0Idx Index of the first pinned vertex (placed at the UV origin)
      * @param pin1Idx Index of the second pinned vertex (placed on the nearest axis)
      * @throws SolverException If matrix cannot be decomposed or if solver fails
@@ -3441,6 +3459,7 @@ struct Quadric {
     {
     }
 
+    /** In-place accumulation of another quadric */
     auto operator+=(const Quadric& o) -> Quadric&
     {
         for (std::size_t i = 0; i < 10; ++i) {
@@ -3449,6 +3468,7 @@ struct Quadric {
         return *this;
     }
 
+    /** Quadric addition */
     friend auto operator+(Quadric a, const Quadric& b) -> Quadric { return a += b; }
 
     /** Evaluate quadric error at point (x, y, z) */
@@ -3859,6 +3879,7 @@ public:
     }
 
 private:
+    /// \cond INTERNAL
     void computeQuadrics_()
     {
         for (auto& q : quadrics_) {
@@ -3969,6 +3990,7 @@ private:
     std::vector<std::size_t> scratchNbrsA_;
     std::vector<std::size_t> scratchNbrsB_;
     std::vector<std::size_t> scratchSharedNbrs_;
+    /// \endcond
 };
 
 /**
@@ -4410,6 +4432,12 @@ private:
         }
     }
 
+    /**
+     * @brief Core hierarchical LSCM solve given resolved pin indices
+     *
+     * Builds the mesh hierarchy, solves LSCM at the coarsest level, then
+     * prolongates and refines at each finer level.
+     */
     static void ComputeImpl(typename Mesh::Pointer& mesh, std::size_t pin0Idx, std::size_t pin1Idx,
                             std::size_t levelRatio = 10, std::size_t minCoarseVerts = 100)
     {
@@ -4465,7 +4493,9 @@ private:
 
     /** Optional explicit pin pair */
     std::optional<std::pair<std::size_t, std::size_t>> pinnedVertices_;
+    /** Ratio of vertices between consecutive hierarchy levels */
     std::size_t levelRatio_{10};
+    /** Minimum vertex count for the coarsest hierarchy level */
     std::size_t minCoarseVertices_{100};
 };
 

--- a/single_include/OpenABF/OpenABF.hpp
+++ b/single_include/OpenABF/OpenABF.hpp
@@ -520,14 +520,18 @@ auto remove_if(ForwardContainer v, UnaryPred p)
  */
 template <typename Iter>
 struct Range {
-    /// \cond INTERNAL
+    /** First iterator in the range. */
     Iter first_;
+    /** One-past-last iterator in the range. */
     Iter last_;
+    /** Range begin iterator. */
     auto begin() const -> Iter { return first_; }
+    /** Range end iterator. */
     auto end() const -> Iter { return last_; }
+    /** True if the range is empty. */
     auto empty() const -> bool { return first_ == last_; }
+    /** First element of the range. */
     auto front() const -> decltype(*first_) { return *first_; }
-    /// \endcond
 };
 
 /**
@@ -540,22 +544,31 @@ template <typename Iter, typename Pred>
 class FilteringIterator
 {
 public:
-    /// \cond INTERNAL
+    /** Difference type. */
     using difference_type = std::ptrdiff_t;
+    /** Value type. */
     using value_type = typename std::iterator_traits<Iter>::value_type;
+    /** Pointer type. */
     using pointer = typename std::iterator_traits<Iter>::pointer;
+    /** Reference type. */
     using reference = typename std::iterator_traits<Iter>::reference;
+    /** Iterator category. */
     using iterator_category = std::input_iterator_tag;
 
+    /** Default constructor. */
     FilteringIterator() = default;
+    /** Construct over `[current, end)` filtering by `pred`. */
     FilteringIterator(Iter current, Iter end, Pred pred) : current_{current}, end_{end}, pred_{pred}
     {
         advance_to_next();
     }
 
+    /** Dereference. */
     auto operator*() const -> reference { return *current_; }
+    /** Member access. */
     auto operator->() const -> pointer { return &*current_; }
 
+    /** Pre-increment; skips elements failing `pred`. */
     auto operator++() -> FilteringIterator&
     {
         ++current_;
@@ -563,15 +576,16 @@ public:
         return *this;
     }
 
+    /** Equality. */
     auto operator==(const FilteringIterator& other) const -> bool
     {
         return current_ == other.current_;
     }
+    /** Inequality. */
     auto operator!=(const FilteringIterator& other) const -> bool { return !(*this == other); }
-    /// \endcond
 
 private:
-    /// \cond INTERNAL
+    /** Advance `current_` past elements failing `pred_`. */
     void advance_to_next()
     {
         while (current_ != end_ && !pred_(*current_)) {
@@ -579,10 +593,12 @@ private:
         }
     }
 
+    /** Underlying iterator position. */
     Iter current_{};
+    /** Underlying end iterator. */
     Iter end_{};
+    /** Predicate selecting which elements to visit. */
     Pred pred_{};
-    /// \endcond
 };
 }  // namespace detail
 
@@ -970,7 +986,7 @@ private:
         }
 
     private:
-        /// \cond INTERNAL
+        /** Advance `current_` past boundary edges, wrapping to `nullptr` at end. */
         void advance_to_non_boundary()
         {
             while (current_ && current_->is_boundary()) {
@@ -982,9 +998,10 @@ private:
             }
         }
 
+        /** First edge in the wheel (used to detect wrap-around). */
         EdgePtr head_{};
+        /** Current edge in the wheel; `nullptr` at end. */
         EdgePtr current_{};
-        /// \endcond
     };
 
     /**
@@ -1060,7 +1077,7 @@ private:
         }
 
     private:
-        /// \cond INTERNAL
+        /** Advance `faceIt_` until a face with remaining edges is found, or the end is reached. */
         void advance_if_face_exhausted()
         {
             while (edgeIt_ == FaceIterator<true>() && faceIt_ != faceEnd_) {
@@ -1071,10 +1088,12 @@ private:
             }
         }
 
+        /** Current position in the face vector. */
         FaceVecIter faceIt_{};
+        /** End of the face vector. */
         FaceVecIter faceEnd_{};
+        /** Edge iterator within the current face. */
         FaceIterator<true> edgeIt_{};
-        /// \endcond
     };
 
 public:
@@ -3879,7 +3898,7 @@ public:
     }
 
 private:
-    /// \cond INTERNAL
+    /** Recompute per-vertex QEM quadrics from the live faces (Garland-Heckbert). */
     void computeQuadrics_()
     {
         for (auto& q : quadrics_) {
@@ -3915,6 +3934,7 @@ private:
         }
     }
 
+    /** Rebuild the unique-edge list from the live faces. */
     void buildEdges_()
     {
         edges_.clear();
@@ -3971,26 +3991,41 @@ private:
         return {u, v, w};
     }
 
+    /** Per-vertex 3D positions, indexed by original vertex index. */
     std::vector<Vec<T, 3>> positions_;
+    /** Per-vertex alive flag; collapses set entries to false. */
     std::vector<bool> alive_;
+    /** Per-vertex boundary flag, copied from the source mesh. */
     std::vector<bool> isBoundary_;
+    /** Per-vertex pinned flag; pinned vertices cannot be removed by collapse. */
     std::vector<bool> isPinned_;
+    /** Per-vertex QEM quadrics accumulated from incident face planes. */
     std::vector<Quadric<T>> quadrics_;
+    /** Face connectivity: each face is three vertex indices into `positions_`. */
     std::vector<std::array<std::size_t, 3>> faces_;
+    /** Per-face alive flag; collapses retire faces by setting entries to false. */
     std::vector<bool> faceAlive_;
+    /** Per-vertex incident face list. */
     std::vector<std::vector<std::size_t>> vertFaces_;
+    /** Count of alive vertices (kept current across collapses). */
     std::size_t numAliveVerts_{0};
+    /** Count of alive faces (kept current across collapses). */
     std::size_t numAliveFaces_{0};
+    /** Unique-edge list, rebuilt on demand by `buildEdges_()`. */
     std::vector<std::pair<std::size_t, std::size_t>> edges_;
 
-    // Scratch storage reused across tryCollapse calls (avoids repeated heap allocation)
+    /** Scratch buffer: neighbor indices shared between two endpoints. */
     std::vector<std::size_t> scratchShared_;
+    /** Scratch buffer: faces to retire on a collapse. */
     std::vector<std::size_t> scratchRemove_;
+    /** Scratch buffer: post-collapse face rewrites. */
     std::vector<std::array<std::size_t, 3>> scratchPostFaces_;
+    /** Scratch buffer: neighbor list of one endpoint. */
     std::vector<std::size_t> scratchNbrsA_;
+    /** Scratch buffer: neighbor list of the other endpoint. */
     std::vector<std::size_t> scratchNbrsB_;
+    /** Scratch buffer: deduplicated union of `scratchNbrsA_` and `scratchNbrsB_`. */
     std::vector<std::size_t> scratchSharedNbrs_;
-    /// \endcond
 };
 
 /**


### PR DESCRIPTION
## Summary

Clears all 58 pre-existing Doxygen warnings (58 → 0) in the public headers, with no API changes.

### Categories addressed
- **Broken `@copydoc` target** in `HalfEdgeMesh::insert_vertices` (initializer_list overload): replaced with an inline brief.
- **Missing `@param mesh`** on `AngleBasedLSCM::Compute(mesh, pin0Idx, pin1Idx)`: added.
- **`HalfEdgeMesh::WheelIterator` / `EdgesIterator`**: documented all members inline (`operator*` overloads, `FaceVecIter` typedef, iterator state, `advance_*` helpers).
- **`detail::Range` / `detail::FilteringIterator`**: documented all members inline (range endpoints, iterator typedefs, predicate state, advance helper).
- **`detail::hlscm::Quadric` operators (`+=`, `friend +`)**: brief one-liners.
- **`detail::hlscm::DecimationMesh`**: documented every member of the private section (helper methods, flat-array state, scratch buffers).
- **`HierarchicalLSCM` private `ComputeImpl`, `levelRatio_`, `minCoarseVertices_`**: brief one-liners.

### Conventions
- No `@internal` tags reintroduced (PR #88 removed those project-wide).
- No `\cond INTERNAL` blocks. The project deliberately doesn't surface a "concept of internal docs" — the `detail::` namespace is the only API-stability signal, and for private members of public classes the consistent answer is brief inline docs rather than hiding them.
- `EXTRACT_PRIVATE = YES` and `INTERNAL_DOCS = NO` are unchanged.
- `single_include/OpenABF/OpenABF.hpp` regenerated via the amalgamation script.

## Test plan

- [x] `cmake --build /tmp/openabf-doxy --target docs` — 58 warnings → 0
- [x] `cmake --build build_claude` succeeds in multi-header mode
- [x] `ctest --output-on-failure -j 4` — 6/6 tests pass (includes `OpenABF_TestParameterization`)
- [x] `git clang-format` clean on all touched headers
- [x] `single_include/OpenABF/OpenABF.hpp` regenerated and included

🤖 Generated with [Claude Code](https://claude.com/claude-code)