### PR TITLE
feat(lscm): multi-pin UV constraints on ABLSCM and HLSCM

### DIFF
--- a/conductor/tracks.md
+++ b/conductor/tracks.md
@@ -2,22 +2,16 @@
 
 ## Next Up
 
-Planned work order (updated 2026-06-13; A8 landed in PR #88, P6 closed as obsolete):
+Planned work order (updated 2026-06-14; P4 landed in PR #91, P5 landed in PR #92):
 
-1. The following run **in parallel** (each on its own branch):
-   - **P4** — IncompleteCholesky preconditioner (touches `AngleBasedLSCM` solver
-     dispatch only; independent of HLSCM internals).
-   - **P5** — HLSCM hot-path allocation reduction (touches HLSCM hierarchy data
-     structures and `prolongateUVs` / UV map return type; minimal overlap with
-     A8's `detail::lscm::buildSystem` extraction).
+No parallel pair currently scheduled. Next pick from the active list — A7,
+A10, F2, or F5–F11 — based on priority at the time of starting.
 
 ## Active Tracks
 
 | Status | Track ID | Title | GitHub | Created | Updated |
 | ------ | -------- | ----- | ------ | ------- | ------- |
-| open | P4 | IncompleteCholesky preconditioner for AngleBasedLSCM | [#47](https://github.com/educelab/OpenABF/issues/47) | 2026-03-18 | 2026-06-13 |
-| open | P5 | HLSCM hot-path allocation reduction (UV map, vertexNeighbors, originalToLocal) | [#63](https://github.com/educelab/OpenABF/issues/63) | 2026-03-20 | 2026-06-13 |
-| open | A7 | Multi-pin UV constraints for LSCM | [#42](https://github.com/educelab/OpenABF/issues/42) | 2026-03-16 | 2026-03-16 |
+| in_progress | A7 | Multi-pin UV constraints for LSCM and Hierarchical LSCM | [#42](https://github.com/educelab/OpenABF/issues/42) | 2026-03-16 | 2026-06-14 |
 | open | A10 | Add static Compute() overloads accepting levelRatio and minCoarseVertices | [#68](https://github.com/educelab/OpenABF/issues/68) | 2026-03-20 | 2026-03-20 |
 | open | F5 | Implement Hierarchical SLIM (H-SLIM) | [#52](https://github.com/educelab/OpenABF/issues/52) | 2026-03-20 | 2026-03-20 |
 | open | F6 | Migrate to C++20 | [#54](https://github.com/educelab/OpenABF/issues/54) | 2026-03-20 | 2026-03-20 |
@@ -32,6 +26,8 @@ Planned work order (updated 2026-06-13; A8 landed in PR #88, P6 closed as obsole
 
 | Status | Track ID | Title | GitHub | Archived |
 | ------ | -------- | ----- | ------ | -------- |
+| closed | P5 | HLSCM hot-path allocation reduction (UV map, vertexNeighbors, originalToLocal) — PR #92 | [#63](https://github.com/educelab/OpenABF/issues/63) | 2026-06-14 |
+| closed | P4 | IncompleteCholesky preconditioner for AngleBasedLSCM (benchmarked; SparseLU stays default) — PR #91 | [#47](https://github.com/educelab/OpenABF/issues/47) | 2026-06-14 |
 | closed | P6 | Precompute sin/cos values before HLSCM face assembly loop (obsolete — post-A8 loop has no trig redundancy to eliminate) | [#66](https://github.com/educelab/OpenABF/issues/66) | 2026-06-13 |
 | closed | A8 | Extract shared LSCM system-building logic from solveLSCMLevel and ComputeImpl (PR #88) | [#64](https://github.com/educelab/OpenABF/issues/64) | 2026-06-13 |
 | closed | E2 | Add sphere cap built-in mesh generator to benchmark | [#48](https://github.com/educelab/OpenABF/issues/48) | 2026-06-12 |

--- a/conductor/tracks/A7/plan.md
+++ b/conductor/tracks/A7/plan.md
@@ -21,39 +21,68 @@ Confirmed Red: `cmake --build . --target OpenABF_TestParameterization` fails
 with 12 unknown-symbol errors (`PinMap`, `setPins`); no regressions in
 existing tests.
 
-## Phase 2: Shared assembly helper
-- [ ] 2.1 Add `detail::lscm::buildSystemMultiPin(mesh, pins)` in
-  `LSCMSystem.hpp`. Takes a `std::vector<std::pair<size_t, Vec<T,2>>>`. No
-  axis-snap; pin positions are written verbatim to the mesh and into `bFixed`.
-  Returns the existing `SystemParts<T>` shape.
-- [ ] 2.2 Keep the two-pin `buildSystem(mesh, p0, p1)` overload — it stays the
-  home of the LSCM axis-snap auto-placement convention used by the
-  default/two-pin code paths.
+## Phase 2: Migrate `detail::lscm::buildSystem` to PinMap-only
+Per user direction 2026-06-14: no two-arg compat. PinMap is the only explicit
+pin API in this codebase after this migration.
 
-## Phase 3: ABLSCM multi-pin
-- [ ] 3.1 Define `using PinMap = std::vector<std::pair<std::size_t, Vec<T,2>>>`
-  inside `AngleBasedLSCM`.
-- [ ] 3.2 Add `Compute(mesh, PinMap)` static overload. Validates pins ≥ 2,
-  unique indices, in-range; dispatches through `buildSystemMultiPin`.
-- [ ] 3.3 Add `setPins(PinMap)` and `pins_` (`std::optional<PinMap>`).
-- [ ] 3.4 Update `compute()` to prefer `pins_` over `pinnedVertices_` when set.
+- [x] 2.1 Redesign `buildSystem` to a single signature
+  `buildSystem(mesh, PinMap)` (no axis-snap inside; caller provides UVs
+  verbatim). Mutates each pinned vertex's `pos` to its specified UV, then
+  emits the LSCM least-squares system with those values in `bFixed`.
+- [x] 2.2 Migrate `LSCMSystemBuild.*` tests + `BuildPyramidSystem` helper to
+  the new signature.
 
-## Phase 4: HLSCM multi-pin
-- [ ] 4.1 Generalize `DecimationMesh::build` to accept a span/vector of pin
-  indices and flag each as `isPinned_[i] = true`.
-- [ ] 4.2 Generalize `buildHierarchy` to forward the pin set to `build`.
-- [ ] 4.3 Generalize `solveLSCMLevel` to take a PinMap; map each pin's original
-  idx to its level-local idx, write the user's UV into the level-mesh vertex
-  positions, build via `buildSystemMultiPin`, and write each pin back in the
-  output UV vector.
-- [ ] 4.4 Update initial-guess builder to skip *every* pin (not just p0/p1).
-- [ ] 4.5 Add `HierarchicalLSCM::Compute(mesh, PinMap)` and `setPins(PinMap)`.
-- [ ] 4.6 Update `compute()` to prefer `pins_` over `pinnedVertices_`.
+## Phase 3: ABLSCM full migration to PinMap (with deprecated 2-pin shim)
+Per user direction 2026-06-14: retain `Compute(mesh, p0, p1)` and
+`setPinnedVertices(p0, p1)` as `[[deprecated]]` shims slated for removal in
+3.0. Both forward to the PinMap path with axis-snap UVs.
 
-## Phase 5: Verify
-- [ ] 5.1 Run `ctest` — all existing tests pass unchanged.
-- [ ] 5.2 New multi-pin tests pass.
-- [ ] 5.3 Run `git clang-format`; regenerate amalgamated header.
+- [x] 3.1 Define `using PinMap = std::vector<std::pair<std::size_t, Vec<T,2>>>`
+  in `AngleBasedLSCM`.
+- [x] 3.2 Add private helpers `selectBoundaryPair(mesh)` and
+  `autoPlacePair(mesh, p0Idx, p1Idx) -> PinMap` (the existing axis-snap
+  convention). `autoSelectPins(mesh) = autoPlacePair(mesh,
+  selectBoundaryPair(mesh)...)`.
+- [x] 3.3 Rewrite `Compute(mesh)`: build PinMap via `autoSelectPins`, then
+  call `ComputeImpl(mesh, pins)`.
+- [x] 3.4 Add `Compute(mesh, PinMap)` static overload (validates pins ≥ 2,
+  unique indices, in-range).
+- [x] 3.5 Add `setPins(PinMap)` and `pins_` (`std::optional<PinMap>`).
+- [x] 3.6 Restore `Compute(mesh, p0Idx, p1Idx)` and
+  `setPinnedVertices(p0, p1)` as `[[deprecated]]` shims that build an
+  axis-snap PinMap and delegate. Update `compute()` dispatch to handle
+  legacy indices stored by the shim.
+- [x] 3.7 Keep `AngleBasedLSCM_ExplicitPins`, `_Reversed`,
+  `_SetPinnedVertices` — they now exercise the deprecated-shim path and
+  must continue to pass until 3.0.
+
+## Phase 4: HLSCM full migration to PinMap (with deprecated 2-pin shim)
+- [x] 4.1 `DecimationMesh::build` takes `std::vector<std::size_t>` pinIndices;
+  flag each as `isPinned_[idx] = true`.
+- [x] 4.2 `buildHierarchy` takes the pinIndices vector and forwards.
+- [x] 4.3 `solveLSCMLevel` takes a PinMap; map each pin's original idx to its
+  level-local idx, write the user's UV into the level mesh, run buildSystem,
+  copy each pin back into the output UV vector.
+- [x] 4.4 Update initial-guess builder to skip every pin (not just p0/p1).
+- [x] 4.5 In `HierarchicalLSCM`: add `PinMap` alias, `autoSelectPins` helper
+  using the existing axis-snap convention, `Compute(mesh)`,
+  `Compute(mesh, PinMap)`, `setPins`, `pins_`, and rewrite `compute()`
+  dispatch.
+- [x] 4.6 Single-level fallback delegates to
+  `AngleBasedLSCM::Compute(mesh, PinMap)`.
+- [x] 4.7 Restore `Compute(mesh, pin0Idx, pin1Idx)` and
+  `setPinnedVertices(p0, p1)` as `[[deprecated]]` shims (parallel to ABLSCM).
+- [x] 4.8 Migrate internal tests that pass the two-arg form to the new
+  signature (`std::vector<std::size_t>` for `DecimationMesh::build` and
+  `buildHierarchy`; `PinMap` for `solveLSCMLevel`).
+- [x] 4.9 Keep `HLSCM.ExplicitPins`, `HLSCM.SetPinnedVertices` — they now
+  exercise the deprecated-shim path and must continue to pass until 3.0.
+
+## Phase 5: Verify — done
+- [x] 5.1 Run `ctest` — 6/6 binaries, 50/50 parameterization assertions pass.
+- [x] 5.2 New multi-pin tests pass (5/5 new + 5 deprecated-shim tests still
+  green).
+- [x] 5.3 Run `git clang-format`; regenerate amalgamated header.
 
 ## Phase 6: Conductor & GitHub
 - [ ] 6.1 Open PR against issue #42; note expanded scope (HLSCM included) in PR

--- a/conductor/tracks/A7/plan.md
+++ b/conductor/tracks/A7/plan.md
@@ -6,16 +6,20 @@ Scope expanded 2026-06-14: multi-pin now covers both `AngleBasedLSCM` and
 `HierarchicalLSCM`. Most of the work lives in a shared `detail::lscm`
 assembly helper used by both solvers.
 
-## Phase 1: Tests (Red)
-- [ ] 1.1 ABLSCM: 3-pin pyramid test — pin three vertices with explicit UV
+## Phase 1: Tests (Red) — done
+- [x] 1.1 ABLSCM: 3-pin pyramid test — pin three vertices with explicit UV
   coordinates; verify each lands exactly at its specified UV.
-- [ ] 1.2 ABLSCM: instance-form test — `setPins(PinMap)` + `compute()` produces
+- [x] 1.2 ABLSCM: instance-form test — `setPins(PinMap)` + `compute()` produces
   the same result as the static `Compute(mesh, PinMap)` overload.
-- [ ] 1.3 HLSCM: 3-pin pyramid test (single-level fallback path) — verify each
+- [x] 1.3 HLSCM: 3-pin pyramid test (single-level fallback path) — verify each
   pin lands at its specified UV.
-- [ ] 1.4 HLSCM: 3-pin hemisphere test (multi-level path) — verify pins survive
+- [x] 1.4 HLSCM: 3-pin hemisphere test (multi-level path) — verify pins survive
   every hierarchy level and land at the specified UVs.
-- [ ] 1.5 HLSCM: instance-form test — `setPins(PinMap)` + `compute()`.
+- [x] 1.5 HLSCM: instance-form test — `setPins(PinMap)` + `compute()`.
+
+Confirmed Red: `cmake --build . --target OpenABF_TestParameterization` fails
+with 12 unknown-symbol errors (`PinMap`, `setPins`); no regressions in
+existing tests.
 
 ## Phase 2: Shared assembly helper
 - [ ] 2.1 Add `detail::lscm::buildSystemMultiPin(mesh, pins)` in

--- a/conductor/tracks/A7/plan.md
+++ b/conductor/tracks/A7/plan.md
@@ -1,16 +1,57 @@
 # A7 Implementation Plan
 
-## Phase 1: Tests
-- [ ] 1.1 Add a test pinning three vertices of the pyramid with explicit UV coordinates and verifying each lands at the specified position
-- [ ] 1.2 Add a test using the instance form `setPins()` + `compute()`
+Branch: `a7-multi-pin-lscm`.
 
-## Phase 2: Implementation
-- [ ] 2.1 Define `using PinMap = std::vector<std::pair<std::size_t, Vec<T, 2>>>` inside `AngleBasedLSCM`
-- [ ] 2.2 Refactor `ComputeImpl` (introduced by A5) to accept a `PinMap` instead of two vertex pointers; build `bFixed` and the free/fixed split from the map
-- [ ] 2.3 Add `Compute(mesh, PinMap)` static overload
-- [ ] 2.4 Add `setPins(PinMap)` instance method and `pins_` member (`std::optional<PinMap>`)
-- [ ] 2.5 Update `compute()` to call the PinMap overload when `pins_` is set
+Scope expanded 2026-06-14: multi-pin now covers both `AngleBasedLSCM` and
+`HierarchicalLSCM`. Most of the work lives in a shared `detail::lscm`
+assembly helper used by both solvers.
 
-## Phase 3: Verify
-- [ ] 3.1 Run `ctest`
-- [ ] 3.2 Confirm all existing tests (default and two-pin paths) pass unchanged
+## Phase 1: Tests (Red)
+- [ ] 1.1 ABLSCM: 3-pin pyramid test — pin three vertices with explicit UV
+  coordinates; verify each lands exactly at its specified UV.
+- [ ] 1.2 ABLSCM: instance-form test — `setPins(PinMap)` + `compute()` produces
+  the same result as the static `Compute(mesh, PinMap)` overload.
+- [ ] 1.3 HLSCM: 3-pin pyramid test (single-level fallback path) — verify each
+  pin lands at its specified UV.
+- [ ] 1.4 HLSCM: 3-pin hemisphere test (multi-level path) — verify pins survive
+  every hierarchy level and land at the specified UVs.
+- [ ] 1.5 HLSCM: instance-form test — `setPins(PinMap)` + `compute()`.
+
+## Phase 2: Shared assembly helper
+- [ ] 2.1 Add `detail::lscm::buildSystemMultiPin(mesh, pins)` in
+  `LSCMSystem.hpp`. Takes a `std::vector<std::pair<size_t, Vec<T,2>>>`. No
+  axis-snap; pin positions are written verbatim to the mesh and into `bFixed`.
+  Returns the existing `SystemParts<T>` shape.
+- [ ] 2.2 Keep the two-pin `buildSystem(mesh, p0, p1)` overload — it stays the
+  home of the LSCM axis-snap auto-placement convention used by the
+  default/two-pin code paths.
+
+## Phase 3: ABLSCM multi-pin
+- [ ] 3.1 Define `using PinMap = std::vector<std::pair<std::size_t, Vec<T,2>>>`
+  inside `AngleBasedLSCM`.
+- [ ] 3.2 Add `Compute(mesh, PinMap)` static overload. Validates pins ≥ 2,
+  unique indices, in-range; dispatches through `buildSystemMultiPin`.
+- [ ] 3.3 Add `setPins(PinMap)` and `pins_` (`std::optional<PinMap>`).
+- [ ] 3.4 Update `compute()` to prefer `pins_` over `pinnedVertices_` when set.
+
+## Phase 4: HLSCM multi-pin
+- [ ] 4.1 Generalize `DecimationMesh::build` to accept a span/vector of pin
+  indices and flag each as `isPinned_[i] = true`.
+- [ ] 4.2 Generalize `buildHierarchy` to forward the pin set to `build`.
+- [ ] 4.3 Generalize `solveLSCMLevel` to take a PinMap; map each pin's original
+  idx to its level-local idx, write the user's UV into the level-mesh vertex
+  positions, build via `buildSystemMultiPin`, and write each pin back in the
+  output UV vector.
+- [ ] 4.4 Update initial-guess builder to skip *every* pin (not just p0/p1).
+- [ ] 4.5 Add `HierarchicalLSCM::Compute(mesh, PinMap)` and `setPins(PinMap)`.
+- [ ] 4.6 Update `compute()` to prefer `pins_` over `pinnedVertices_`.
+
+## Phase 5: Verify
+- [ ] 5.1 Run `ctest` — all existing tests pass unchanged.
+- [ ] 5.2 New multi-pin tests pass.
+- [ ] 5.3 Run `git clang-format`; regenerate amalgamated header.
+
+## Phase 6: Conductor & GitHub
+- [ ] 6.1 Open PR against issue #42; note expanded scope (HLSCM included) in PR
+  description.
+- [ ] 6.2 Update `tracks.md` (move A7 to archived once PR lands).

--- a/conductor/tracks/A7/plan.md
+++ b/conductor/tracks/A7/plan.md
@@ -85,6 +85,6 @@ Per user direction 2026-06-14: retain `Compute(mesh, p0, p1)` and
 - [x] 5.3 Run `git clang-format`; regenerate amalgamated header.
 
 ## Phase 6: Conductor & GitHub
-- [ ] 6.1 Open PR against issue #42; note expanded scope (HLSCM included) in PR
-  description.
+- [x] 6.1 PR #93 opened against #42; PR description notes expanded scope
+  (HLSCM included) and the deprecated-shim plan for 3.0 removal.
 - [ ] 6.2 Update `tracks.md` (move A7 to archived once PR lands).

--- a/conductor/tracks/A7/spec.md
+++ b/conductor/tracks/A7/spec.md
@@ -1,23 +1,44 @@
-# A7 — Multi-pin UV constraints for LSCM
+# A7 — Multi-pin UV constraints for LSCM and Hierarchical LSCM
 
 ## GitHub Issue
 https://github.com/educelab/OpenABF/issues/42
 
 ## Summary
-`AngleBasedLSCM` supports pinning exactly two vertices. Allowing the caller to
-supply three or more vertices with explicit UV positions enables boundary stitching
-in multi-component pipelines (F3), fitting patches to an atlas, and reducing
-distortion by adding anchors along the boundary.
+`AngleBasedLSCM` and `HierarchicalLSCM` currently support pinning exactly two
+vertices. Allowing the caller to supply three or more vertices with explicit UV
+positions enables boundary stitching in multi-component pipelines (F3), fitting
+patches to an atlas, and reducing distortion by adding anchors along the
+boundary.
 
-## File
-`include/OpenABF/AngleBasedLSCM.hpp`
+Multi-pin support is added to **both** solvers via a shared assembly helper.
+Pins are guaranteed to survive every decimation level in HLSCM (the existing
+`isPinned_` mechanism already protects them from collapse), so HLSCM multi-pin
+is achievable without algorithmic changes — only API surface and per-level
+bookkeeping.
+
+## Files
+- `include/OpenABF/detail/LSCMSystem.hpp` — new `buildSystemMultiPin(mesh, PinMap)`
+  overload that accepts caller-supplied UVs (no axis-snap auto-placement).
+- `include/OpenABF/AngleBasedLSCM.hpp` — multi-pin `Compute` overload + `setPins`.
+- `include/OpenABF/HierarchicalLSCM.hpp` — multi-pin `Compute` overload + `setPins`;
+  generalize `DecimationMesh::build` to flag all pins as non-collapsible;
+  generalize `solveLSCMLevel` to map a PinMap to level-local indices.
 
 ## Acceptance Criteria
-- [ ] `Compute(mesh, PinMap)` overload added where `PinMap` is
-  `std::vector<std::pair<std::size_t, Vec<T,2>>>`
-- [ ] `setPins(PinMap)` method added to the instance form
-- [ ] All existing tests (default two-pin path and A5 explicit two-pin) pass unchanged
-- [ ] Tests verify that pinned vertices land exactly at the specified UV positions
+- [ ] `using PinMap = std::vector<std::pair<std::size_t, Vec<T,2>>>` defined and
+  re-exported by both `AngleBasedLSCM` and `HierarchicalLSCM`
+- [ ] `AngleBasedLSCM::Compute(mesh, PinMap)` static overload + `setPins(PinMap)`
+  instance method
+- [ ] `HierarchicalLSCM::Compute(mesh, PinMap)` static overload + `setPins(PinMap)`
+  instance method
+- [ ] All existing tests (default two-pin path and A5 explicit two-pin) pass
+  unchanged for both solvers
+- [ ] Tests verify that pinned vertices land exactly at the specified UV
+  positions for both solvers (≥3 pins)
+- [ ] Tests cover the instance form (`setPins() + compute()`) for both solvers
+- [ ] HLSCM with many pins still builds a valid hierarchy (or gracefully falls
+  back to single-level LSCM when decimation is exhausted)
 
 ## Dependencies
-- A5 (two-pin explicit override) must be merged first
+- A5 (two-pin explicit override) merged
+- F1 (HLSCM) merged

--- a/conductor/tracks/P4/index.md
+++ b/conductor/tracks/P4/index.md
@@ -1,6 +1,6 @@
 # P4 — IncompleteCholesky preconditioner for AngleBasedLSCM
 
-**Status:** open
+**Status:** closed (PR #91 merged)
 **Issue:** https://github.com/educelab/OpenABF/issues/47
 **Dependencies:** E1
 

--- a/conductor/tracks/P4/plan.md
+++ b/conductor/tracks/P4/plan.md
@@ -27,6 +27,6 @@ The gap *widens* with mesh size: IC-CG is being dominated by IncompleteCholesky'
 - [x] 2.5 Regenerate amalgamated header — single_include updated.
 
 ## Phase 3: Conductor & GitHub
-- [ ] 3.1 Commit and push (waiting on signing availability)
-- [ ] 3.2 Open PR against #47 describing the benchmark, the conclusion, and the doc update; close issue #47 as "investigated, default unchanged"
-- [ ] 3.3 Update tracks.md (move P4 to archived once PR lands)
+- [x] 3.1 Commit and push.
+- [x] 3.2 PR #91 opened and merged against #47; benchmark/conclusion/doc update recorded; issue #47 closed as "investigated, default unchanged".
+- [x] 3.3 Update tracks.md (P4 moved to archived).

--- a/conductor/tracks/P5/index.md
+++ b/conductor/tracks/P5/index.md
@@ -1,6 +1,6 @@
 # P5 — HLSCM hot-path allocation reduction
 
-**Status:** open
+**Status:** closed (PR #92 merged)
 **Issue:** https://github.com/educelab/OpenABF/issues/63
 **Dependencies:** F1
 

--- a/conductor/tracks/P5/plan.md
+++ b/conductor/tracks/P5/plan.md
@@ -40,4 +40,4 @@ If a future profiling pass shows `buildEdges_` becoming a meaningful share of th
 ## Phase 7: Conductor & GitHub
 - [x] 7.1 Commits pushed (phases 1–4 only): `a14d34a`, `baf00bb`.
 - [x] 7.2 PR #92 open against #63.
-- [ ] 7.3 Update `tracks.md` (move P5 to archived once PR lands).
+- [x] 7.3 Update `tracks.md` (move P5 to archived once PR lands).

--- a/include/OpenABF/AngleBasedLSCM.hpp
+++ b/include/OpenABF/AngleBasedLSCM.hpp
@@ -1,7 +1,12 @@
 #pragma once
 
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <iterator>
 #include <optional>
 #include <type_traits>
+#include <unordered_set>
 #include <utility>
 
 #include <Eigen/IterativeLinearSolvers>
@@ -10,6 +15,7 @@
 #include "OpenABF/Exceptions.hpp"
 #include "OpenABF/HalfEdgeMesh.hpp"
 #include "OpenABF/Math.hpp"
+#include "OpenABF/Vec.hpp"
 #include "OpenABF/detail/LSCMSystem.hpp"
 
 namespace OpenABF
@@ -121,17 +127,48 @@ public:
     /** @brief Mesh type alias */
     using Mesh = MeshType;
 
-    /** @brief Set the pinned vertex indices used by compute() */
-    void setPinnedVertices(std::size_t pin0Idx, std::size_t pin1Idx)
+    /**
+     * @brief Per-pin entry: (mesh vertex index, target UV).
+     *
+     * A `PinMap` of size N ≥ 2 specifies an explicit LSCM pin set; each pinned
+     * vertex's final UV equals its entry in the map.
+     */
+    using PinMap = detail::lscm::PinMap<T>;
+
+    /**
+     * @brief Set the explicit pin set used by `compute()`
+     *
+     * The PinMap must contain at least two unique, in-range vertex indices;
+     * `compute()` rejects malformed inputs at solve time.
+     */
+    void setPins(PinMap pins)
     {
-        pinnedVertices_ = {pin0Idx, pin1Idx};
+        pins_ = std::move(pins);
+        legacyPinIndices_.reset();
+    }
+
+    /**
+     * @brief Deprecated: set a pin pair by index using the LSCM axis-snap
+     * convention at compute time.
+     *
+     * @deprecated Prefer `setPins(PinMap)`. This overload will be removed in
+     * version 3.0.
+     */
+    [[deprecated("Use setPins(PinMap); will be removed in 3.0")]] void setPinnedVertices(
+        std::size_t pin0Idx, std::size_t pin1Idx)
+    {
+        legacyPinIndices_ = {pin0Idx, pin1Idx};
+        pins_.reset();
     }
 
     /** @copydoc AngleBasedLSCM::Compute() */
     void compute(typename Mesh::Pointer& mesh) const
     {
-        if (pinnedVertices_) {
-            Compute(mesh, pinnedVertices_->first, pinnedVertices_->second);
+        if (pins_) {
+            Compute(mesh, *pins_);
+        } else if (legacyPinIndices_) {
+            ComputeImpl(mesh,
+                        autoPlacePair(mesh, legacyPinIndices_->first, legacyPinIndices_->second));
         } else {
             Compute(mesh);
         }
@@ -141,16 +178,65 @@ public:
      * @brief Compute the parameterized mesh using automatic pin selection
      *
      * Selects the first boundary vertex and its boundary-edge neighbor as
-     * pinned vertices.
+     * pinned vertices, placing pin0 at the UV origin and pin1 at distance
+     * `|p1 - p0|` along the dominant world-axis of `(p1 - p0)`.
      *
-     * @throws MeshException If pinned vertex is not on boundary.
+     * @throws MeshException If pin selection fails (no boundary vertices).
      * @throws SolverException If matrix cannot be decomposed or if solver fails
      * to find a solution.
      */
-    static void Compute(typename Mesh::Pointer& mesh)
+    static void Compute(typename Mesh::Pointer& mesh) { ComputeImpl(mesh, autoSelectPins(mesh)); }
+
+    /**
+     * @brief Compute the parameterized mesh with caller-specified pin UVs
+     *
+     * @param mesh Triangle mesh whose vertex positions will be overwritten with
+     * computed 2D UV coordinates (z component set to 0).
+     * @param pins Sequence of (vertex index, target UV) pairs. Must contain at
+     * least two unique, in-range vertex indices. Each pinned vertex's final UV
+     * equals the supplied target verbatim.
+     * @throws std::invalid_argument If `pins` has fewer than two entries, a
+     * duplicate index, or an out-of-range index.
+     * @throws SolverException If matrix cannot be decomposed or if solver fails
+     * to find a solution.
+     */
+    static void Compute(typename Mesh::Pointer& mesh, const PinMap& pins)
     {
-        // Pinned vertex selection: first boundary vertex + boundary-edge neighbor
-        auto p0 = mesh->vertices_boundary().front();
+        validatePins(mesh, pins);
+        ComputeImpl(mesh, pins);
+    }
+
+    /**
+     * @brief Deprecated: compute with an explicit pin pair by index.
+     *
+     * Builds a 2-entry PinMap using the LSCM axis-snap convention (pin0 at the
+     * UV origin, pin1 on the dominant world-axis of `(p1 - p0)`) and
+     * dispatches to the PinMap path.
+     *
+     * @deprecated Prefer `Compute(mesh, PinMap)`. This overload will be
+     * removed in version 3.0.
+     */
+    [[deprecated("Use Compute(mesh, PinMap); will be removed in 3.0")]] static void Compute(
+        typename Mesh::Pointer& mesh, std::size_t pin0Idx, std::size_t pin1Idx)
+    {
+        ComputeImpl(mesh, autoPlacePair(mesh, pin0Idx, pin1Idx));
+    }
+
+private:
+    /** Optional explicit pin set configured via `setPins()`. */
+    std::optional<PinMap> pins_;
+    /** Deprecated: legacy two-pin index pair set via `setPinnedVertices`. */
+    std::optional<std::pair<std::size_t, std::size_t>> legacyPinIndices_;
+
+    /** Walk the boundary to pick the default pin pair. */
+    static auto selectBoundaryPair(const typename Mesh::Pointer& mesh)
+        -> std::pair<typename Mesh::VertPtr, typename Mesh::VertPtr>
+    {
+        auto boundary = mesh->vertices_boundary();
+        if (boundary.empty()) {
+            throw MeshException("AngleBasedLSCM: mesh has no boundary vertices");
+        }
+        auto p0 = boundary.front();
         auto e = p0->edge;
         do {
             if (e->pair->is_boundary()) {
@@ -162,47 +248,85 @@ public:
             throw MeshException("Pinned vertex not on boundary");
         }
         auto p1 = e->next->vertex;
-        ComputeImpl(mesh, p0, p1);
+        return {p0, p1};
     }
 
     /**
-     * @brief Compute the parameterized mesh with explicit pinned vertex indices
+     * @brief Build a 2-entry PinMap from explicit indices using the LSCM
+     * axis-snap convention.
      *
-     * @param mesh Triangle mesh whose vertex positions will be overwritten with
-     * computed 2D UV coordinates (z component set to 0).
-     * @param pin0Idx Index of the first pinned vertex (placed at the UV origin)
-     * @param pin1Idx Index of the second pinned vertex (placed on the nearest axis)
-     * @throws SolverException If matrix cannot be decomposed or if solver fails
-     * to find a solution.
+     * pin0 at `{0, 0}`, pin1 at signed distance `|p1 - p0|` on whichever world
+     * axis the `(p1 - p0)` vector has the largest magnitude.
      */
-    static void Compute(typename Mesh::Pointer& mesh, std::size_t pin0Idx, std::size_t pin1Idx)
+    static auto autoPlacePair(const typename Mesh::Pointer& mesh, std::size_t p0Idx,
+                              std::size_t p1Idx) -> PinMap
     {
-        ComputeImpl(mesh, mesh->vertex(pin0Idx), mesh->vertex(pin1Idx));
+        auto p0 = mesh->vertex(p0Idx);
+        auto p1 = mesh->vertex(p1Idx);
+        auto pinVec = p1->pos - p0->pos;
+        auto dist = norm(pinVec);
+        pinVec /= dist;
+        auto maxElem = std::max_element(pinVec.begin(), pinVec.end());
+        auto maxAxis = std::distance(pinVec.begin(), maxElem);
+        dist = std::copysign(dist, *maxElem);
+        Vec<T, 2> uv0{T(0), T(0)};
+        Vec<T, 2> uv1 = (maxAxis == 0) ? Vec<T, 2>{dist, T(0)} : Vec<T, 2>{T(0), dist};
+        return PinMap{{p0Idx, uv0}, {p1Idx, uv1}};
     }
 
-private:
-    /** Optional explicit pin pair set via setPinnedVertices() */
-    std::optional<std::pair<std::size_t, std::size_t>> pinnedVertices_;
+    /**
+     * @brief Auto-select two boundary pins and place them via the LSCM
+     * axis-snap convention.
+     */
+    static auto autoSelectPins(const typename Mesh::Pointer& mesh) -> PinMap
+    {
+        auto [p0, p1] = selectBoundaryPair(mesh);
+        return autoPlacePair(mesh, p0->idx, p1->idx);
+    }
+
+    /** Validate that the user's PinMap is well-formed for this mesh. */
+    static void validatePins(const typename Mesh::Pointer& mesh, const PinMap& pins)
+    {
+        if (pins.size() < 2) {
+            throw std::invalid_argument("AngleBasedLSCM: PinMap requires at least 2 pins");
+        }
+        auto numVerts = mesh->num_vertices();
+        std::unordered_set<std::size_t> seen;
+        seen.reserve(pins.size());
+        for (const auto& [vIdx, uv] : pins) {
+            if (vIdx >= numVerts) {
+                throw std::invalid_argument("AngleBasedLSCM: PinMap vertex index out of range");
+            }
+            if (!seen.insert(vIdx).second) {
+                throw std::invalid_argument("AngleBasedLSCM: PinMap has duplicate vertex index");
+            }
+        }
+    }
 
     /**
-     * @brief Core solver: place p0/p1 on the UV axes then solve for free vertices
+     * @brief Core solver: build the LSCM system from the PinMap, solve for free
+     * vertices, and write UVs back to the mesh.
      */
-    static void ComputeImpl(typename Mesh::Pointer& mesh, const typename Mesh::VertPtr& p0,
-                            const typename Mesh::VertPtr& p1)
+    static void ComputeImpl(typename Mesh::Pointer& mesh, const PinMap& pins)
     {
         using SparseMatrix = Eigen::SparseMatrix<T>;
         using DenseMatrix = Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>;
 
         // Pin placement + LSCM system assembly (shared with HierarchicalLSCM)
-        auto parts = detail::lscm::buildSystem<T, Mesh>(mesh, p0, p1);
+        auto parts = detail::lscm::buildSystem<T, Mesh>(mesh, pins);
 
         // Solve for x
         auto x = detail::SolveLeastSquares<SparseMatrix, DenseMatrix, Solver>(parts.A, parts.b);
 
-        // Assign solution to UV coordinates
-        // Pins are already updated by buildSystem, so these are free vertices
+        // Assign solution to free vertices. Pin vertices are already at their
+        // target UVs (written by buildSystem).
+        std::unordered_set<std::size_t> pinIdx;
+        pinIdx.reserve(pins.size());
+        for (const auto& [vIdx, uv] : pins) {
+            pinIdx.insert(vIdx);
+        }
         for (const auto& v : mesh->vertices()) {
-            if (v == p0 or v == p1) {
+            if (pinIdx.count(v->idx)) {
                 continue;
             }
             auto newIdx = 2 * parts.freeIdxTable.at(v->idx);

--- a/include/OpenABF/AngleBasedLSCM.hpp
+++ b/include/OpenABF/AngleBasedLSCM.hpp
@@ -141,7 +141,7 @@ public:
      * The PinMap must contain at least two unique, in-range vertex indices;
      * `compute()` rejects malformed inputs at solve time.
      */
-    void setPins(PinMap pins)
+    void set_pins(PinMap pins)
     {
         pins_ = std::move(pins);
         legacyPinIndices_.reset();
@@ -151,10 +151,10 @@ public:
      * @brief Deprecated: set a pin pair by index using the LSCM axis-snap
      * convention at compute time.
      *
-     * @deprecated Prefer `setPins(PinMap)`. This overload will be removed in
+     * @deprecated Prefer `set_pins(PinMap)`. This overload will be removed in
      * version 3.0.
      */
-    [[deprecated("Use setPins(PinMap); will be removed in 3.0")]] void setPinnedVertices(
+    [[deprecated("Use set_pins(PinMap); will be removed in 3.0")]] void setPinnedVertices(
         std::size_t pin0Idx, std::size_t pin1Idx)
     {
         legacyPinIndices_ = {pin0Idx, pin1Idx};
@@ -167,7 +167,7 @@ public:
         if (pins_) {
             Compute(mesh, *pins_);
         } else if (legacyPinIndices_) {
-            ComputeImpl(mesh, detail::lscm::autoPlacePair<T, Mesh>(mesh, legacyPinIndices_->first,
+            ComputeImpl(mesh, detail::lscm::AutoPlacePair<T, Mesh>(mesh, legacyPinIndices_->first,
                                                                    legacyPinIndices_->second));
         } else {
             Compute(mesh);
@@ -185,7 +185,10 @@ public:
      * @throws SolverException If matrix cannot be decomposed or if solver fails
      * to find a solution.
      */
-    static void Compute(typename Mesh::Pointer& mesh) { ComputeImpl(mesh, autoSelectPins(mesh)); }
+    static void Compute(typename Mesh::Pointer& mesh)
+    {
+        ComputeImpl(mesh, detail::lscm::AutoSelectPins<T, Mesh>(mesh));
+    }
 
     /**
      * @brief Compute the parameterized mesh with caller-specified pin UVs
@@ -202,7 +205,7 @@ public:
      */
     static void Compute(typename Mesh::Pointer& mesh, const PinMap& pins)
     {
-        detail::lscm::validatePins<T, Mesh>(mesh, pins);
+        detail::lscm::ValidatePins<T, Mesh>(mesh, pins);
         ComputeImpl(mesh, pins);
     }
 
@@ -219,44 +222,14 @@ public:
     [[deprecated("Use Compute(mesh, PinMap); will be removed in 3.0")]] static void Compute(
         typename Mesh::Pointer& mesh, std::size_t pin0Idx, std::size_t pin1Idx)
     {
-        ComputeImpl(mesh, detail::lscm::autoPlacePair<T, Mesh>(mesh, pin0Idx, pin1Idx));
+        ComputeImpl(mesh, detail::lscm::AutoPlacePair<T, Mesh>(mesh, pin0Idx, pin1Idx));
     }
 
 private:
-    /** Optional explicit pin set configured via `setPins()`. */
+    /** Optional explicit pin set configured via `set_pins()`. */
     std::optional<PinMap> pins_;
     /** Deprecated: legacy two-pin index pair set via `setPinnedVertices`. */
     std::optional<std::pair<std::size_t, std::size_t>> legacyPinIndices_;
-
-    /** Walk the boundary to pick the default pin pair. */
-    static auto selectBoundaryPair(const typename Mesh::Pointer& mesh)
-        -> std::pair<typename Mesh::VertPtr, typename Mesh::VertPtr>
-    {
-        auto boundary = mesh->vertices_boundary();
-        if (boundary.empty()) {
-            throw MeshException("AngleBasedLSCM: mesh has no boundary vertices");
-        }
-        auto p0 = boundary.front();
-        auto e = p0->edge;
-        do {
-            if (e->pair->is_boundary()) {
-                break;
-            }
-            e = e->pair->next;
-        } while (e != p0->edge);
-        if (e == p0->edge and not e->pair->is_boundary()) {
-            throw MeshException("Pinned vertex not on boundary");
-        }
-        auto p1 = e->next->vertex;
-        return {p0, p1};
-    }
-
-    /** Auto-select two boundary pins and place them via the LSCM axis-snap convention. */
-    static auto autoSelectPins(const typename Mesh::Pointer& mesh) -> PinMap
-    {
-        auto [p0, p1] = selectBoundaryPair(mesh);
-        return detail::lscm::autoPlacePair<T, Mesh>(mesh, p0->idx, p1->idx);
-    }
 
     /**
      * @brief Core solver: build the LSCM system from the PinMap, solve for free

--- a/include/OpenABF/AngleBasedLSCM.hpp
+++ b/include/OpenABF/AngleBasedLSCM.hpp
@@ -167,8 +167,8 @@ public:
         if (pins_) {
             Compute(mesh, *pins_);
         } else if (legacyPinIndices_) {
-            ComputeImpl(mesh,
-                        autoPlacePair(mesh, legacyPinIndices_->first, legacyPinIndices_->second));
+            ComputeImpl(mesh, detail::lscm::autoPlacePair<T, Mesh>(mesh, legacyPinIndices_->first,
+                                                                   legacyPinIndices_->second));
         } else {
             Compute(mesh);
         }
@@ -202,7 +202,7 @@ public:
      */
     static void Compute(typename Mesh::Pointer& mesh, const PinMap& pins)
     {
-        validatePins(mesh, pins);
+        detail::lscm::validatePins<T, Mesh>(mesh, pins);
         ComputeImpl(mesh, pins);
     }
 
@@ -219,7 +219,7 @@ public:
     [[deprecated("Use Compute(mesh, PinMap); will be removed in 3.0")]] static void Compute(
         typename Mesh::Pointer& mesh, std::size_t pin0Idx, std::size_t pin1Idx)
     {
-        ComputeImpl(mesh, autoPlacePair(mesh, pin0Idx, pin1Idx));
+        ComputeImpl(mesh, detail::lscm::autoPlacePair<T, Mesh>(mesh, pin0Idx, pin1Idx));
     }
 
 private:
@@ -251,56 +251,11 @@ private:
         return {p0, p1};
     }
 
-    /**
-     * @brief Build a 2-entry PinMap from explicit indices using the LSCM
-     * axis-snap convention.
-     *
-     * pin0 at `{0, 0}`, pin1 at signed distance `|p1 - p0|` on whichever world
-     * axis the `(p1 - p0)` vector has the largest magnitude.
-     */
-    static auto autoPlacePair(const typename Mesh::Pointer& mesh, std::size_t p0Idx,
-                              std::size_t p1Idx) -> PinMap
-    {
-        auto p0 = mesh->vertex(p0Idx);
-        auto p1 = mesh->vertex(p1Idx);
-        auto pinVec = p1->pos - p0->pos;
-        auto dist = norm(pinVec);
-        pinVec /= dist;
-        auto maxElem = std::max_element(pinVec.begin(), pinVec.end());
-        auto maxAxis = std::distance(pinVec.begin(), maxElem);
-        dist = std::copysign(dist, *maxElem);
-        Vec<T, 2> uv0{T(0), T(0)};
-        Vec<T, 2> uv1 = (maxAxis == 0) ? Vec<T, 2>{dist, T(0)} : Vec<T, 2>{T(0), dist};
-        return PinMap{{p0Idx, uv0}, {p1Idx, uv1}};
-    }
-
-    /**
-     * @brief Auto-select two boundary pins and place them via the LSCM
-     * axis-snap convention.
-     */
+    /** Auto-select two boundary pins and place them via the LSCM axis-snap convention. */
     static auto autoSelectPins(const typename Mesh::Pointer& mesh) -> PinMap
     {
         auto [p0, p1] = selectBoundaryPair(mesh);
-        return autoPlacePair(mesh, p0->idx, p1->idx);
-    }
-
-    /** Validate that the user's PinMap is well-formed for this mesh. */
-    static void validatePins(const typename Mesh::Pointer& mesh, const PinMap& pins)
-    {
-        if (pins.size() < 2) {
-            throw std::invalid_argument("AngleBasedLSCM: PinMap requires at least 2 pins");
-        }
-        auto numVerts = mesh->num_vertices();
-        std::unordered_set<std::size_t> seen;
-        seen.reserve(pins.size());
-        for (const auto& [vIdx, uv] : pins) {
-            if (vIdx >= numVerts) {
-                throw std::invalid_argument("AngleBasedLSCM: PinMap vertex index out of range");
-            }
-            if (!seen.insert(vIdx).second) {
-                throw std::invalid_argument("AngleBasedLSCM: PinMap has duplicate vertex index");
-            }
-        }
+        return detail::lscm::autoPlacePair<T, Mesh>(mesh, p0->idx, p1->idx);
     }
 
     /**
@@ -312,19 +267,22 @@ private:
         using SparseMatrix = Eigen::SparseMatrix<T>;
         using DenseMatrix = Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>;
 
-        // Pin placement + LSCM system assembly (shared with HierarchicalLSCM)
+        // LSCM system assembly (shared with HierarchicalLSCM). buildSystem
+        // does not mutate the mesh; pin UVs are written below.
         auto parts = detail::lscm::buildSystem<T, Mesh>(mesh, pins);
 
         // Solve for x
         auto x = detail::SolveLeastSquares<SparseMatrix, DenseMatrix, Solver>(parts.A, parts.b);
 
-        // Assign solution to free vertices. Pin vertices are already at their
-        // target UVs (written by buildSystem).
+        // Write pin UVs onto the mesh from the PinMap.
         std::unordered_set<std::size_t> pinIdx;
         pinIdx.reserve(pins.size());
         for (const auto& [vIdx, uv] : pins) {
+            auto v = mesh->vertex(vIdx);
+            v->pos = {uv[0], uv[1], T(0)};
             pinIdx.insert(vIdx);
         }
+        // Write solved UVs onto each free vertex.
         for (const auto& v : mesh->vertices()) {
             if (pinIdx.count(v->idx)) {
                 continue;

--- a/include/OpenABF/HierarchicalLSCM.hpp
+++ b/include/OpenABF/HierarchicalLSCM.hpp
@@ -116,7 +116,7 @@ class DecimationMesh
 public:
     /** Build from a HalfEdgeMesh */
     template <class MeshPtr>
-    void build(const MeshPtr& mesh, std::size_t pin0, std::size_t pin1)
+    void build(const MeshPtr& mesh, const std::vector<std::size_t>& pinIndices)
     {
         auto nv = mesh->num_vertices();
         auto nf = mesh->num_faces();
@@ -127,8 +127,9 @@ public:
         isPinned_.assign(nv, false);
         quadrics_.resize(nv);
 
-        isPinned_[pin0] = true;
-        isPinned_[pin1] = true;
+        for (auto idx : pinIndices) {
+            isPinned_[idx] = true;
+        }
 
         for (const auto& v : mesh->vertices()) {
             positions_[v->idx] = v->pos;
@@ -643,12 +644,12 @@ private:
  * the collapse records needed for prolongation (ordered from finest to coarsest).
  */
 template <typename T, class MeshPtr>
-auto buildHierarchy(const MeshPtr& mesh, std::size_t pin0, std::size_t pin1, std::size_t levelRatio,
-                    std::size_t minCoarseVerts)
+auto buildHierarchy(const MeshPtr& mesh, const std::vector<std::size_t>& pinIndices,
+                    std::size_t levelRatio, std::size_t minCoarseVerts)
     -> std::pair<std::vector<HierarchyLevel<T>>, std::vector<std::vector<CollapseRecord<T>>>>
 {
     DecimationMesh<T> dmesh;
-    dmesh.build(mesh, pin0, pin1);
+    dmesh.build(mesh, pinIndices);
 
     // Finest level snapshot
     std::vector<HierarchyLevel<T>> levels;
@@ -794,8 +795,8 @@ auto prolongateUVs(UVVector<T> uvs, const std::vector<CollapseRecord<T>>& collap
  */
 template <typename T, class SolverType>
 auto solveLSCMLevel(const typename HalfEdgeMesh<T>::Pointer& levelMesh,
-                    const detail::hlscm::HierarchyLevel<T>& level, std::size_t origPin0,
-                    std::size_t origPin1, std::size_t origVertCount,
+                    const detail::hlscm::HierarchyLevel<T>& level,
+                    const detail::lscm::PinMap<T>& origPins, std::size_t origVertCount,
                     const UVVector<T>* initialGuess) -> UVVector<T>
 {
     using SparseMatrix = Eigen::SparseMatrix<T>;
@@ -803,18 +804,23 @@ auto solveLSCMLevel(const typename HalfEdgeMesh<T>::Pointer& levelMesh,
     using Mesh = HalfEdgeMesh<T>;
 
     auto numVerts = levelMesh->num_vertices();
-    constexpr std::size_t numFixed = 2;
+    auto numFixed = origPins.size();
     auto numFree = numVerts - numFixed;
 
-    // Map original pin indices to level-local indices. Pins are guaranteed
+    // Map each original pin idx to its level-local idx. Pins are guaranteed
     // to survive every decimation level so the unwrap is safe.
-    auto localPin0 = *level.originalToLocal[origPin0];
-    auto localPin1 = *level.originalToLocal[origPin1];
-    auto p0 = levelMesh->vertex(localPin0);
-    auto p1 = levelMesh->vertex(localPin1);
+    detail::lscm::PinMap<T> localPins;
+    localPins.reserve(numFixed);
+    std::unordered_set<std::size_t> localPinIdx;
+    localPinIdx.reserve(numFixed);
+    for (const auto& [origIdx, uv] : origPins) {
+        auto localIdx = *level.originalToLocal[origIdx];
+        localPins.emplace_back(localIdx, uv);
+        localPinIdx.insert(localIdx);
+    }
 
     // Pin placement + LSCM system assembly (shared with AngleBasedLSCM)
-    auto parts = detail::lscm::buildSystem<T, Mesh>(levelMesh, p0, p1);
+    auto parts = detail::lscm::buildSystem<T, Mesh>(levelMesh, localPins);
     auto& A = parts.A;
     auto& b = parts.b;
     auto& freeIdxTable = parts.freeIdxTable;
@@ -826,7 +832,7 @@ auto solveLSCMLevel(const typename HalfEdgeMesh<T>::Pointer& levelMesh,
     auto buildInitialGuess = [&]() -> DenseMatrix {
         DenseMatrix x0 = DenseMatrix::Zero(2 * numFree, 1);
         for (const auto& v : levelMesh->vertices()) {
-            if (v == p0 || v == p1) {
+            if (localPinIdx.count(v->idx)) {
                 continue;
             }
             auto freeIdx = freeIdxTable.at(v->idx);
@@ -897,10 +903,11 @@ auto solveLSCMLevel(const typename HalfEdgeMesh<T>::Pointer& levelMesh,
     // present at this level remain nullopt; they will be filled in by
     // prolongation when undoing collapses at finer levels.
     UVVector<T> uvs(origVertCount);
-    uvs[level.localToOriginal[p0->idx]] = Vec<T, 2>(p0->pos[0], p0->pos[1]);
-    uvs[level.localToOriginal[p1->idx]] = Vec<T, 2>(p1->pos[0], p1->pos[1]);
+    for (const auto& [origIdx, uv] : origPins) {
+        uvs[origIdx] = uv;
+    }
     for (const auto& v : levelMesh->vertices()) {
-        if (v == p0 || v == p1) {
+        if (localPinIdx.count(v->idx)) {
             continue;
         }
         auto freeIdx = 2 * freeIdxTable.at(v->idx);
@@ -963,10 +970,36 @@ public:
     /** @brief Mesh type alias */
     using Mesh = MeshType;
 
-    /** @brief Set the pinned vertex indices used by compute() */
-    void setPinnedVertices(std::size_t pin0Idx, std::size_t pin1Idx)
+    /**
+     * @brief Per-pin entry: (mesh vertex index, target UV).
+     *
+     * A PinMap of size N ≥ 2 specifies an explicit LSCM pin set. Each pin
+     * survives every decimation level — `DecimationMesh::tryCollapse` rejects
+     * any collapse that would remove a pinned vertex.
+     */
+    using PinMap = detail::lscm::PinMap<T>;
+
+    /**
+     * @brief Set the explicit pin set used by `compute()`
+     */
+    void setPins(PinMap pins)
     {
-        pinnedVertices_ = {pin0Idx, pin1Idx};
+        pins_ = std::move(pins);
+        legacyPinIndices_.reset();
+    }
+
+    /**
+     * @brief Deprecated: set a pin pair by index using the LSCM axis-snap
+     * convention at compute time.
+     *
+     * @deprecated Prefer `setPins(PinMap)`. This overload will be removed in
+     * version 3.0.
+     */
+    [[deprecated("Use setPins(PinMap); will be removed in 3.0")]] void setPinnedVertices(
+        std::size_t pin0Idx, std::size_t pin1Idx)
+    {
+        legacyPinIndices_ = {pin0Idx, pin1Idx};
+        pins_.reset();
     }
 
     /** @brief Set the vertex ratio between consecutive hierarchy levels (default: 10) */
@@ -990,55 +1023,71 @@ public:
     /**
      * @brief Compute parameterization using instance configuration
      *
-     * Uses the pinned vertices, level ratio, and minimum coarse vertices
-     * configured via `setPinnedVertices()`, `setLevelRatio()`, and
-     * `setMinCoarseVertices()`. If no pins are set, selects them automatically
-     * using the same boundary-walk logic as `Compute(mesh)`.
+     * If `setPins()` was called, uses the supplied PinMap. Otherwise, if the
+     * deprecated `setPinnedVertices()` was called, builds a PinMap from those
+     * indices via the LSCM axis-snap convention. Otherwise auto-selects two
+     * boundary vertices using the same logic as `Compute(mesh)`.
      *
      * @throws MeshException if pin selection fails (no boundary vertices)
      * @throws SolverException if any hierarchy level fails to solve
      */
     void compute(typename Mesh::Pointer& mesh) const
     {
-        std::size_t p0, p1;
-        if (pinnedVertices_) {
-            p0 = pinnedVertices_->first;
-            p1 = pinnedVertices_->second;
+        PinMap pins;
+        if (pins_) {
+            pins = *pins_;
+        } else if (legacyPinIndices_) {
+            pins = autoPlacePair(mesh, legacyPinIndices_->first, legacyPinIndices_->second);
         } else {
-            AutoSelectPins(mesh, p0, p1);
+            pins = autoSelectPins(mesh);
         }
-        ComputeImpl(mesh, p0, p1, levelRatio_, minCoarseVertices_);
+        ComputeImpl(mesh, pins, levelRatio_, minCoarseVertices_);
     }
 
     /**
      * @brief Compute with automatic pin selection
      *
-     * Selects pins identically to AngleBasedLSCM::Compute().
+     * Selects pins identically to AngleBasedLSCM::Compute() — first boundary
+     * vertex and its boundary-edge neighbor, placed via LSCM axis-snap.
      *
      * @throws MeshException if the mesh has no boundary vertices (pin selection
      *         fails) or the mesh is otherwise invalid
      * @throws SolverException if any hierarchy level fails to solve
      */
-    static void Compute(typename Mesh::Pointer& mesh)
+    static void Compute(typename Mesh::Pointer& mesh) { ComputeImpl(mesh, autoSelectPins(mesh)); }
+
+    /**
+     * @brief Compute with caller-specified pin UVs
+     *
+     * @throws std::invalid_argument If `pins` has fewer than two entries, a
+     * duplicate index, or an out-of-range index.
+     * @throws SolverException If any hierarchy level fails to solve.
+     */
+    static void Compute(typename Mesh::Pointer& mesh, const PinMap& pins)
     {
-        std::size_t p0, p1;
-        AutoSelectPins(mesh, p0, p1);
-        ComputeImpl(mesh, p0, p1);
+        validatePins(mesh, pins);
+        ComputeImpl(mesh, pins);
     }
 
     /**
-     * @brief Compute with explicit pinned vertex indices
+     * @brief Deprecated: compute with an explicit pin pair by index.
      *
-     * @throws SolverException if any hierarchy level fails to solve
+     * Builds a 2-entry PinMap using the LSCM axis-snap convention and
+     * dispatches to the PinMap path.
+     *
+     * @deprecated Prefer `Compute(mesh, PinMap)`. This overload will be
+     * removed in version 3.0.
      */
-    static void Compute(typename Mesh::Pointer& mesh, std::size_t pin0Idx, std::size_t pin1Idx)
+    [[deprecated("Use Compute(mesh, PinMap); will be removed in 3.0")]] static void Compute(
+        typename Mesh::Pointer& mesh, std::size_t pin0Idx, std::size_t pin1Idx)
     {
-        ComputeImpl(mesh, pin0Idx, pin1Idx);
+        ComputeImpl(mesh, autoPlacePair(mesh, pin0Idx, pin1Idx));
     }
 
 private:
-    /** Select two pinned boundary vertices (same logic as AngleBasedLSCM) */
-    static void AutoSelectPins(const typename Mesh::Pointer& mesh, std::size_t& p0, std::size_t& p1)
+    /** Walk the boundary to pick the default pin pair as (idx, idx). */
+    static auto selectBoundaryPair(const typename Mesh::Pointer& mesh)
+        -> std::pair<std::size_t, std::size_t>
     {
         auto boundary = mesh->vertices_boundary();
         if (boundary.empty()) {
@@ -1055,8 +1104,54 @@ private:
         if (e == v0->edge && !e->pair->is_boundary()) {
             throw MeshException("Pinned vertex not on boundary");
         }
-        p0 = v0->idx;
-        p1 = e->next->vertex->idx;
+        return {v0->idx, e->next->vertex->idx};
+    }
+
+    /**
+     * @brief Build a 2-entry PinMap from explicit indices using the LSCM
+     * axis-snap convention (pin0 at the UV origin, pin1 on the dominant
+     * world-axis of `(p1 - p0)`).
+     */
+    static auto autoPlacePair(const typename Mesh::Pointer& mesh, std::size_t p0Idx,
+                              std::size_t p1Idx) -> PinMap
+    {
+        auto p0 = mesh->vertex(p0Idx);
+        auto p1 = mesh->vertex(p1Idx);
+        auto pinVec = p1->pos - p0->pos;
+        auto dist = norm(pinVec);
+        pinVec /= dist;
+        auto maxElem = std::max_element(pinVec.begin(), pinVec.end());
+        auto maxAxis = std::distance(pinVec.begin(), maxElem);
+        dist = std::copysign(dist, *maxElem);
+        Vec<T, 2> uv0{T(0), T(0)};
+        Vec<T, 2> uv1 = (maxAxis == 0) ? Vec<T, 2>{dist, T(0)} : Vec<T, 2>{T(0), dist};
+        return PinMap{{p0Idx, uv0}, {p1Idx, uv1}};
+    }
+
+    /** Auto-select two boundary pins and place them via axis-snap. */
+    static auto autoSelectPins(const typename Mesh::Pointer& mesh) -> PinMap
+    {
+        auto [p0Idx, p1Idx] = selectBoundaryPair(mesh);
+        return autoPlacePair(mesh, p0Idx, p1Idx);
+    }
+
+    /** Validate the user-supplied PinMap against `mesh`. */
+    static void validatePins(const typename Mesh::Pointer& mesh, const PinMap& pins)
+    {
+        if (pins.size() < 2) {
+            throw std::invalid_argument("HierarchicalLSCM: PinMap requires at least 2 pins");
+        }
+        auto numVerts = mesh->num_vertices();
+        std::unordered_set<std::size_t> seen;
+        seen.reserve(pins.size());
+        for (const auto& [vIdx, uv] : pins) {
+            if (vIdx >= numVerts) {
+                throw std::invalid_argument("HierarchicalLSCM: PinMap vertex index out of range");
+            }
+            if (!seen.insert(vIdx).second) {
+                throw std::invalid_argument("HierarchicalLSCM: PinMap has duplicate vertex index");
+            }
+        }
     }
 
     /**
@@ -1083,22 +1178,31 @@ private:
     }
 
     /**
-     * @brief Core hierarchical LSCM solve given resolved pin indices
+     * @brief Core hierarchical LSCM solve given a resolved PinMap
      *
-     * Builds the mesh hierarchy, solves LSCM at the coarsest level, then
-     * prolongates and refines at each finer level.
+     * Builds the mesh hierarchy with each pinned vertex flagged as
+     * non-collapsible, solves LSCM at the coarsest level, then prolongates and
+     * refines at each finer level. Pin UVs come from the PinMap verbatim;
+     * non-pin vertex UVs are written by the solve.
      */
-    static void ComputeImpl(typename Mesh::Pointer& mesh, std::size_t pin0Idx, std::size_t pin1Idx,
+    static void ComputeImpl(typename Mesh::Pointer& mesh, const PinMap& pins,
                             std::size_t levelRatio = 10, std::size_t minCoarseVerts = 100)
     {
+        // Extract just the indices for the hierarchy's non-collapsible set.
+        std::vector<std::size_t> pinIndices;
+        pinIndices.reserve(pins.size());
+        for (const auto& [vIdx, uv] : pins) {
+            pinIndices.push_back(vIdx);
+        }
+
         // Build mesh hierarchy
         auto [levels, collapsesByLevel] =
-            detail::hlscm::buildHierarchy<T>(mesh, pin0Idx, pin1Idx, levelRatio, minCoarseVerts);
+            detail::hlscm::buildHierarchy<T>(mesh, pinIndices, levelRatio, minCoarseVerts);
 
         if (levels.size() <= 1) {
-            // Mesh too small for hierarchy — single-level LSCM solve
-            // Use AngleBasedLSCM for exact equivalence on small meshes
-            AngleBasedLSCM<T, MeshType, Solver>::Compute(mesh, pin0Idx, pin1Idx);
+            // Mesh too small for hierarchy — single-level LSCM solve.
+            // Delegate to AngleBasedLSCM with the same pins.
+            AngleBasedLSCM<T, MeshType, Solver>::Compute(mesh, pins);
             return;
         }
 
@@ -1110,8 +1214,8 @@ private:
         auto coarsestIdx = levels.size() - 1;
         auto coarseMesh = detail::hlscm::buildLevelMesh<T>(levels[coarsestIdx]);
         ComputeMeshAngles(coarseMesh);
-        auto uvs = detail::hlscm::solveLSCMLevel<T, Solver>(
-            coarseMesh, levels[coarsestIdx], pin0Idx, pin1Idx, origVertCount, nullptr);
+        auto uvs = detail::hlscm::solveLSCMLevel<T, Solver>(coarseMesh, levels[coarsestIdx], pins,
+                                                            origVertCount, nullptr);
 
         // Prolongate and refine at each finer level
         for (std::size_t k = coarsestIdx; k-- > 0;) {
@@ -1130,7 +1234,7 @@ private:
             }
 
             // Solve with initial guess
-            uvs = detail::hlscm::solveLSCMLevel<T, Solver>(levelMesh, levels[k], pin0Idx, pin1Idx,
+            uvs = detail::hlscm::solveLSCMLevel<T, Solver>(levelMesh, levels[k], pins,
                                                            origVertCount, &uvs);
         }
 
@@ -1144,8 +1248,10 @@ private:
         }
     }
 
-    /** Optional explicit pin pair */
-    std::optional<std::pair<std::size_t, std::size_t>> pinnedVertices_;
+    /** Optional explicit pin set configured via `setPins()`. */
+    std::optional<PinMap> pins_;
+    /** Deprecated: legacy two-pin index pair set via `setPinnedVertices`. */
+    std::optional<std::pair<std::size_t, std::size_t>> legacyPinIndices_;
     /** Ratio of vertices between consecutive hierarchy levels */
     std::size_t levelRatio_{10};
     /** Minimum vertex count for the coarsest hierarchy level */

--- a/include/OpenABF/HierarchicalLSCM.hpp
+++ b/include/OpenABF/HierarchicalLSCM.hpp
@@ -808,13 +808,21 @@ auto solveLSCMLevel(const typename HalfEdgeMesh<T>::Pointer& levelMesh,
     auto numFree = numVerts - numFixed;
 
     // Map each original pin idx to its level-local idx. Pins are guaranteed
-    // to survive every decimation level so the unwrap is safe.
+    // to survive every decimation level (DecimationMesh::tryCollapse rejects
+    // collapses of pinned vertices), so this unwrap is expected to succeed.
+    // Throw a meaningful exception rather than std::bad_optional_access if a
+    // future refactor ever breaks the invariant.
     detail::lscm::PinMap<T> localPins;
     localPins.reserve(numFixed);
     std::unordered_set<std::size_t> localPinIdx;
     localPinIdx.reserve(numFixed);
     for (const auto& [origIdx, uv] : origPins) {
-        auto localIdx = *level.originalToLocal[origIdx];
+        const auto& localOpt = level.originalToLocal[origIdx];
+        if (!localOpt.has_value()) {
+            throw SolverException(
+                "HLSCM: pinned vertex was removed during decimation (invariant violated)");
+        }
+        auto localIdx = *localOpt;
         localPins.emplace_back(localIdx, uv);
         localPinIdx.insert(localIdx);
     }
@@ -1036,8 +1044,10 @@ public:
         PinMap pins;
         if (pins_) {
             pins = *pins_;
+            detail::lscm::validatePins<T, Mesh>(mesh, pins);
         } else if (legacyPinIndices_) {
-            pins = autoPlacePair(mesh, legacyPinIndices_->first, legacyPinIndices_->second);
+            pins = detail::lscm::autoPlacePair<T, Mesh>(mesh, legacyPinIndices_->first,
+                                                        legacyPinIndices_->second);
         } else {
             pins = autoSelectPins(mesh);
         }
@@ -1065,7 +1075,7 @@ public:
      */
     static void Compute(typename Mesh::Pointer& mesh, const PinMap& pins)
     {
-        validatePins(mesh, pins);
+        detail::lscm::validatePins<T, Mesh>(mesh, pins);
         ComputeImpl(mesh, pins);
     }
 
@@ -1081,7 +1091,7 @@ public:
     [[deprecated("Use Compute(mesh, PinMap); will be removed in 3.0")]] static void Compute(
         typename Mesh::Pointer& mesh, std::size_t pin0Idx, std::size_t pin1Idx)
     {
-        ComputeImpl(mesh, autoPlacePair(mesh, pin0Idx, pin1Idx));
+        ComputeImpl(mesh, detail::lscm::autoPlacePair<T, Mesh>(mesh, pin0Idx, pin1Idx));
     }
 
 private:
@@ -1107,51 +1117,11 @@ private:
         return {v0->idx, e->next->vertex->idx};
     }
 
-    /**
-     * @brief Build a 2-entry PinMap from explicit indices using the LSCM
-     * axis-snap convention (pin0 at the UV origin, pin1 on the dominant
-     * world-axis of `(p1 - p0)`).
-     */
-    static auto autoPlacePair(const typename Mesh::Pointer& mesh, std::size_t p0Idx,
-                              std::size_t p1Idx) -> PinMap
-    {
-        auto p0 = mesh->vertex(p0Idx);
-        auto p1 = mesh->vertex(p1Idx);
-        auto pinVec = p1->pos - p0->pos;
-        auto dist = norm(pinVec);
-        pinVec /= dist;
-        auto maxElem = std::max_element(pinVec.begin(), pinVec.end());
-        auto maxAxis = std::distance(pinVec.begin(), maxElem);
-        dist = std::copysign(dist, *maxElem);
-        Vec<T, 2> uv0{T(0), T(0)};
-        Vec<T, 2> uv1 = (maxAxis == 0) ? Vec<T, 2>{dist, T(0)} : Vec<T, 2>{T(0), dist};
-        return PinMap{{p0Idx, uv0}, {p1Idx, uv1}};
-    }
-
     /** Auto-select two boundary pins and place them via axis-snap. */
     static auto autoSelectPins(const typename Mesh::Pointer& mesh) -> PinMap
     {
         auto [p0Idx, p1Idx] = selectBoundaryPair(mesh);
-        return autoPlacePair(mesh, p0Idx, p1Idx);
-    }
-
-    /** Validate the user-supplied PinMap against `mesh`. */
-    static void validatePins(const typename Mesh::Pointer& mesh, const PinMap& pins)
-    {
-        if (pins.size() < 2) {
-            throw std::invalid_argument("HierarchicalLSCM: PinMap requires at least 2 pins");
-        }
-        auto numVerts = mesh->num_vertices();
-        std::unordered_set<std::size_t> seen;
-        seen.reserve(pins.size());
-        for (const auto& [vIdx, uv] : pins) {
-            if (vIdx >= numVerts) {
-                throw std::invalid_argument("HierarchicalLSCM: PinMap vertex index out of range");
-            }
-            if (!seen.insert(vIdx).second) {
-                throw std::invalid_argument("HierarchicalLSCM: PinMap has duplicate vertex index");
-            }
-        }
+        return detail::lscm::autoPlacePair<T, Mesh>(mesh, p0Idx, p1Idx);
     }
 
     /**

--- a/include/OpenABF/HierarchicalLSCM.hpp
+++ b/include/OpenABF/HierarchicalLSCM.hpp
@@ -990,7 +990,7 @@ public:
     /**
      * @brief Set the explicit pin set used by `compute()`
      */
-    void setPins(PinMap pins)
+    void set_pins(PinMap pins)
     {
         pins_ = std::move(pins);
         legacyPinIndices_.reset();
@@ -1000,10 +1000,10 @@ public:
      * @brief Deprecated: set a pin pair by index using the LSCM axis-snap
      * convention at compute time.
      *
-     * @deprecated Prefer `setPins(PinMap)`. This overload will be removed in
+     * @deprecated Prefer `set_pins(PinMap)`. This overload will be removed in
      * version 3.0.
      */
-    [[deprecated("Use setPins(PinMap); will be removed in 3.0")]] void setPinnedVertices(
+    [[deprecated("Use set_pins(PinMap); will be removed in 3.0")]] void setPinnedVertices(
         std::size_t pin0Idx, std::size_t pin1Idx)
     {
         legacyPinIndices_ = {pin0Idx, pin1Idx};
@@ -1031,7 +1031,7 @@ public:
     /**
      * @brief Compute parameterization using instance configuration
      *
-     * If `setPins()` was called, uses the supplied PinMap. Otherwise, if the
+     * If `set_pins()` was called, uses the supplied PinMap. Otherwise, if the
      * deprecated `setPinnedVertices()` was called, builds a PinMap from those
      * indices via the LSCM axis-snap convention. Otherwise auto-selects two
      * boundary vertices using the same logic as `Compute(mesh)`.
@@ -1044,12 +1044,12 @@ public:
         PinMap pins;
         if (pins_) {
             pins = *pins_;
-            detail::lscm::validatePins<T, Mesh>(mesh, pins);
+            detail::lscm::ValidatePins<T, Mesh>(mesh, pins);
         } else if (legacyPinIndices_) {
-            pins = detail::lscm::autoPlacePair<T, Mesh>(mesh, legacyPinIndices_->first,
+            pins = detail::lscm::AutoPlacePair<T, Mesh>(mesh, legacyPinIndices_->first,
                                                         legacyPinIndices_->second);
         } else {
-            pins = autoSelectPins(mesh);
+            pins = detail::lscm::AutoSelectPins<T, Mesh>(mesh);
         }
         ComputeImpl(mesh, pins, levelRatio_, minCoarseVertices_);
     }
@@ -1064,7 +1064,10 @@ public:
      *         fails) or the mesh is otherwise invalid
      * @throws SolverException if any hierarchy level fails to solve
      */
-    static void Compute(typename Mesh::Pointer& mesh) { ComputeImpl(mesh, autoSelectPins(mesh)); }
+    static void Compute(typename Mesh::Pointer& mesh)
+    {
+        ComputeImpl(mesh, detail::lscm::AutoSelectPins<T, Mesh>(mesh));
+    }
 
     /**
      * @brief Compute with caller-specified pin UVs
@@ -1075,7 +1078,7 @@ public:
      */
     static void Compute(typename Mesh::Pointer& mesh, const PinMap& pins)
     {
-        detail::lscm::validatePins<T, Mesh>(mesh, pins);
+        detail::lscm::ValidatePins<T, Mesh>(mesh, pins);
         ComputeImpl(mesh, pins);
     }
 
@@ -1091,39 +1094,10 @@ public:
     [[deprecated("Use Compute(mesh, PinMap); will be removed in 3.0")]] static void Compute(
         typename Mesh::Pointer& mesh, std::size_t pin0Idx, std::size_t pin1Idx)
     {
-        ComputeImpl(mesh, detail::lscm::autoPlacePair<T, Mesh>(mesh, pin0Idx, pin1Idx));
+        ComputeImpl(mesh, detail::lscm::AutoPlacePair<T, Mesh>(mesh, pin0Idx, pin1Idx));
     }
 
 private:
-    /** Walk the boundary to pick the default pin pair as (idx, idx). */
-    static auto selectBoundaryPair(const typename Mesh::Pointer& mesh)
-        -> std::pair<std::size_t, std::size_t>
-    {
-        auto boundary = mesh->vertices_boundary();
-        if (boundary.empty()) {
-            throw MeshException("HierarchicalLSCM: mesh has no boundary vertices");
-        }
-        auto v0 = boundary.front();
-        auto e = v0->edge;
-        do {
-            if (e->pair->is_boundary()) {
-                break;
-            }
-            e = e->pair->next;
-        } while (e != v0->edge);
-        if (e == v0->edge && !e->pair->is_boundary()) {
-            throw MeshException("Pinned vertex not on boundary");
-        }
-        return {v0->idx, e->next->vertex->idx};
-    }
-
-    /** Auto-select two boundary pins and place them via axis-snap. */
-    static auto autoSelectPins(const typename Mesh::Pointer& mesh) -> PinMap
-    {
-        auto [p0Idx, p1Idx] = selectBoundaryPair(mesh);
-        return detail::lscm::autoPlacePair<T, Mesh>(mesh, p0Idx, p1Idx);
-    }
-
     /**
      * @brief Copy edge angles from the original mesh to a level mesh
      *
@@ -1218,7 +1192,7 @@ private:
         }
     }
 
-    /** Optional explicit pin set configured via `setPins()`. */
+    /** Optional explicit pin set configured via `set_pins()`. */
     std::optional<PinMap> pins_;
     /** Deprecated: legacy two-pin index pair set via `setPinnedVertices`. */
     std::optional<std::pair<std::size_t, std::size_t>> legacyPinIndices_;

--- a/include/OpenABF/detail/LSCMSystem.hpp
+++ b/include/OpenABF/detail/LSCMSystem.hpp
@@ -13,6 +13,7 @@
 
 #include <Eigen/SparseCore>
 
+#include "OpenABF/Exceptions.hpp"
 #include "OpenABF/Math.hpp"
 #include "OpenABF/Vec.hpp"
 
@@ -36,7 +37,7 @@ using PinMap = std::vector<std::pair<std::size_t, OpenABF::Vec<T, 2>>>;
  * boundary.
  */
 template <typename T, class MeshType>
-void validatePins(const typename MeshType::Pointer& mesh, const PinMap<T>& pins)
+void ValidatePins(const typename MeshType::Pointer& mesh, const PinMap<T>& pins)
 {
     if (pins.size() < 2) {
         throw std::invalid_argument("LSCM: PinMap requires at least 2 pins");
@@ -67,8 +68,8 @@ void validatePins(const typename MeshType::Pointer& mesh, const PinMap<T>& pins)
  * either index is out of range.
  */
 template <typename T, class MeshType>
-auto autoPlacePair(const typename MeshType::Pointer& mesh, std::size_t p0Idx,
-                   std::size_t p1Idx) -> PinMap<T>
+auto AutoPlacePair(const typename MeshType::Pointer& mesh, std::size_t p0Idx, std::size_t p1Idx)
+    -> PinMap<T>
 {
     const auto numVerts = mesh->num_vertices();
     if (p0Idx >= numVerts || p1Idx >= numVerts) {
@@ -88,6 +89,39 @@ auto autoPlacePair(const typename MeshType::Pointer& mesh, std::size_t p0Idx,
     Vec<T, 2> uv0{T(0), T(0)};
     Vec<T, 2> uv1 = (maxAxis == 0) ? Vec<T, 2>{dist, T(0)} : Vec<T, 2>{T(0), dist};
     return PinMap<T>{{p0Idx, uv0}, {p1Idx, uv1}};
+}
+
+/**
+ * @brief Auto-select two boundary pins and place them via the LSCM
+ * axis-snap convention.
+ *
+ * Picks the first boundary vertex returned by `mesh->vertices_boundary()` as
+ * pin0 and walks the boundary to find an adjacent boundary vertex as pin1.
+ * UVs follow the axis-snap convention applied by `AutoPlacePair`.
+ *
+ * @throws MeshException if the mesh has no boundary vertices, or if no
+ *         boundary-adjacent neighbor is found for the first boundary vertex.
+ */
+template <typename T, class MeshType>
+auto AutoSelectPins(const typename MeshType::Pointer& mesh) -> PinMap<T>
+{
+    auto boundary = mesh->vertices_boundary();
+    if (boundary.empty()) {
+        throw MeshException("LSCM: mesh has no boundary vertices");
+    }
+    auto p0 = boundary.front();
+    auto e = p0->edge;
+    do {
+        if (e->pair->is_boundary()) {
+            break;
+        }
+        e = e->pair->next;
+    } while (e != p0->edge);
+    if (e == p0->edge && !e->pair->is_boundary()) {
+        throw MeshException("LSCM: pinned vertex not on boundary");
+    }
+    auto p1 = e->next->vertex;
+    return AutoPlacePair<T, MeshType>(mesh, p0->idx, p1->idx);
 }
 
 /**
@@ -121,7 +155,7 @@ struct SystemParts {
  * The function does NOT auto-place pins — UVs are taken verbatim from the
  * PinMap. Callers that want the LSCM axis-snap convention (origin +
  * dominant-axis placement for an auto-selected pair) compute those UVs
- * themselves via `autoPlacePair` before calling this helper.
+ * themselves via `AutoPlacePair` before calling this helper.
  *
  * Assembly follows Lévy et al. 2002 Eq. 10 using the per-edge `alpha` angles
  * already stored on the mesh.

--- a/include/OpenABF/detail/LSCMSystem.hpp
+++ b/include/OpenABF/detail/LSCMSystem.hpp
@@ -67,8 +67,8 @@ void validatePins(const typename MeshType::Pointer& mesh, const PinMap<T>& pins)
  * either index is out of range.
  */
 template <typename T, class MeshType>
-auto autoPlacePair(const typename MeshType::Pointer& mesh, std::size_t p0Idx, std::size_t p1Idx)
-    -> PinMap<T>
+auto autoPlacePair(const typename MeshType::Pointer& mesh, std::size_t p0Idx,
+                   std::size_t p1Idx) -> PinMap<T>
 {
     const auto numVerts = mesh->num_vertices();
     if (p0Idx >= numVerts || p1Idx >= numVerts) {

--- a/include/OpenABF/detail/LSCMSystem.hpp
+++ b/include/OpenABF/detail/LSCMSystem.hpp
@@ -68,8 +68,8 @@ void ValidatePins(const typename MeshType::Pointer& mesh, const PinMap<T>& pins)
  * either index is out of range.
  */
 template <typename T, class MeshType>
-auto AutoPlacePair(const typename MeshType::Pointer& mesh, std::size_t p0Idx, std::size_t p1Idx)
-    -> PinMap<T>
+auto AutoPlacePair(const typename MeshType::Pointer& mesh, std::size_t p0Idx,
+                   std::size_t p1Idx) -> PinMap<T>
 {
     const auto numVerts = mesh->num_vertices();
     if (p0Idx >= numVerts || p1Idx >= numVerts) {

--- a/include/OpenABF/detail/LSCMSystem.hpp
+++ b/include/OpenABF/detail/LSCMSystem.hpp
@@ -4,12 +4,16 @@
 #include <array>
 #include <cmath>
 #include <cstddef>
+#include <iterator>
+#include <stdexcept>
 #include <unordered_map>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
 #include <Eigen/SparseCore>
 
+#include "OpenABF/Math.hpp"
 #include "OpenABF/Vec.hpp"
 
 namespace OpenABF::detail::lscm
@@ -22,6 +26,69 @@ namespace OpenABF::detail::lscm
  */
 template <typename T>
 using PinMap = std::vector<std::pair<std::size_t, OpenABF::Vec<T, 2>>>;
+
+/**
+ * @brief Validate a user-supplied PinMap against `mesh`.
+ *
+ * Throws `std::invalid_argument` if the PinMap has fewer than two pins, a
+ * duplicate vertex index, or an out-of-range vertex index. Shared by
+ * `AngleBasedLSCM` and `HierarchicalLSCM` so behavior matches at the public
+ * boundary.
+ */
+template <typename T, class MeshType>
+void validatePins(const typename MeshType::Pointer& mesh, const PinMap<T>& pins)
+{
+    if (pins.size() < 2) {
+        throw std::invalid_argument("LSCM: PinMap requires at least 2 pins");
+    }
+    const auto numVerts = mesh->num_vertices();
+    std::unordered_set<std::size_t> seen;
+    seen.reserve(pins.size());
+    for (const auto& [vIdx, uv] : pins) {
+        if (vIdx >= numVerts) {
+            throw std::invalid_argument("LSCM: PinMap vertex index out of range");
+        }
+        if (!seen.insert(vIdx).second) {
+            throw std::invalid_argument("LSCM: PinMap has duplicate vertex index");
+        }
+    }
+}
+
+/**
+ * @brief Build a 2-entry PinMap from explicit vertex indices using the LSCM
+ * axis-snap convention.
+ *
+ * pin0 lands at `{0, 0}`; pin1 lands at signed distance `|p1 - p0|` on
+ * whichever world-axis the `(p1 - p0)` vector has the largest magnitude.
+ * Used by the auto-pin path and by the deprecated 2-pin shims.
+ *
+ * Throws `std::invalid_argument` if `p0Idx == p1Idx` (the resulting
+ * zero-length axis-snap would divide by zero and produce NaN UVs) or if
+ * either index is out of range.
+ */
+template <typename T, class MeshType>
+auto autoPlacePair(const typename MeshType::Pointer& mesh, std::size_t p0Idx, std::size_t p1Idx)
+    -> PinMap<T>
+{
+    const auto numVerts = mesh->num_vertices();
+    if (p0Idx >= numVerts || p1Idx >= numVerts) {
+        throw std::invalid_argument("LSCM: pin vertex index out of range");
+    }
+    if (p0Idx == p1Idx) {
+        throw std::invalid_argument("LSCM: pin pair must be two distinct vertices");
+    }
+    auto p0 = mesh->vertex(p0Idx);
+    auto p1 = mesh->vertex(p1Idx);
+    auto pinVec = p1->pos - p0->pos;
+    auto dist = norm(pinVec);
+    pinVec /= dist;
+    auto maxElem = std::max_element(pinVec.begin(), pinVec.end());
+    auto maxAxis = std::distance(pinVec.begin(), maxElem);
+    dist = std::copysign(dist, *maxElem);
+    Vec<T, 2> uv0{T(0), T(0)};
+    Vec<T, 2> uv1 = (maxAxis == 0) ? Vec<T, 2>{dist, T(0)} : Vec<T, 2>{T(0), dist};
+    return PinMap<T>{{p0Idx, uv0}, {p1Idx, uv1}};
+}
 
 /**
  * @brief Outputs of `buildSystem`: the LSCM least-squares system for a mesh
@@ -45,11 +112,16 @@ struct SystemParts {
 /**
  * @brief Build the LSCM sparse system for a mesh with N pinned vertices.
  *
- * Mutates the mesh: each pinned vertex's `pos` is overwritten with `{uv[0],
- * uv[1], 0}` (the caller's chosen UV). The function does NOT auto-place pins
- * — UVs are taken verbatim from the PinMap. Callers that want the LSCM
- * axis-snap convention (origin + dominant-axis placement for an auto-selected
- * pair) compute those UVs themselves before calling this helper.
+ * Pure with respect to the mesh — only reads `alpha` and connectivity. Pin
+ * UVs are taken verbatim from the PinMap into `bFixed`; the mesh's vertex
+ * positions are NOT mutated. Callers that need pin UVs reflected on the mesh
+ * (e.g., `AngleBasedLSCM::ComputeImpl`'s output writeback) must do that
+ * themselves.
+ *
+ * The function does NOT auto-place pins — UVs are taken verbatim from the
+ * PinMap. Callers that want the LSCM axis-snap convention (origin +
+ * dominant-axis placement for an auto-selected pair) compute those UVs
+ * themselves via `autoPlacePair` before calling this helper.
  *
  * Assembly follows Lévy et al. 2002 Eq. 10 using the per-edge `alpha` angles
  * already stored on the mesh.
@@ -72,13 +144,11 @@ auto buildSystem(const typename MeshType::Pointer& mesh, const PinMap<T>& pins) 
         pinSlot.emplace(pins[s].first, s);
     }
 
-    // Write pin UVs into the mesh and into bFixed.
+    // Populate bFixed from PinMap UVs (verbatim).
     std::vector<Triplet> tripletsB;
     tripletsB.reserve(2 * numFixed);
     for (std::size_t s = 0; s < numFixed; ++s) {
-        const auto& [vIdx, uv] = pins[s];
-        auto v = mesh->vertex(vIdx);
-        v->pos = {uv[0], uv[1], T(0)};
+        const auto& uv = pins[s].second;
         tripletsB.emplace_back(2 * s, 0, uv[0]);
         tripletsB.emplace_back(2 * s + 1, 0, uv[1]);
     }

--- a/include/OpenABF/detail/LSCMSystem.hpp
+++ b/include/OpenABF/detail/LSCMSystem.hpp
@@ -4,20 +4,28 @@
 #include <array>
 #include <cmath>
 #include <cstddef>
-#include <iterator>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 
 #include <Eigen/SparseCore>
+
+#include "OpenABF/Vec.hpp"
 
 namespace OpenABF::detail::lscm
 {
 
 /**
- * @brief Outputs of `buildSystem`: the LSCM least-squares system for a mesh
- *        with two pinned vertices.
+ * @brief Per-pin entry: (mesh vertex index, target UV).
  *
- * @tparam T Floating-point type
+ * Shared by `AngleBasedLSCM::PinMap` and `HierarchicalLSCM::PinMap`.
+ */
+template <typename T>
+using PinMap = std::vector<std::pair<std::size_t, OpenABF::Vec<T, 2>>>;
+
+/**
+ * @brief Outputs of `buildSystem`: the LSCM least-squares system for a mesh
+ *        with N pinned vertices (N ≥ 2).
  *
  * Layout: `A` is `(2·numFaces) × (2·numFree)`, `b` is `(2·numFaces) × 1`,
  * `freeIdxTable` maps `vertex->idx` to a row-pair index in `A`/`x` (so a free
@@ -35,62 +43,59 @@ struct SystemParts {
 };
 
 /**
- * @brief Build the LSCM sparse system for a mesh with two pinned vertices.
+ * @brief Build the LSCM sparse system for a mesh with N pinned vertices.
  *
- * Mutates the mesh: places `p0` at the UV origin and `p1` on whichever XY
- * axis its displacement from `p0` has the largest magnitude — same pin
- * placement convention used by `AngleBasedLSCM::ComputeImpl` and
- * `HierarchicalLSCM::solveLSCMLevel`.
+ * Mutates the mesh: each pinned vertex's `pos` is overwritten with `{uv[0],
+ * uv[1], 0}` (the caller's chosen UV). The function does NOT auto-place pins
+ * — UVs are taken verbatim from the PinMap. Callers that want the LSCM
+ * axis-snap convention (origin + dominant-axis placement for an auto-selected
+ * pair) compute those UVs themselves before calling this helper.
  *
  * Assembly follows Lévy et al. 2002 Eq. 10 using the per-edge `alpha` angles
  * already stored on the mesh.
  */
 template <typename T, class MeshType>
-auto buildSystem(const typename MeshType::Pointer& mesh, const typename MeshType::VertPtr& p0,
-                 const typename MeshType::VertPtr& p1) -> SystemParts<T>
+auto buildSystem(const typename MeshType::Pointer& mesh, const PinMap<T>& pins) -> SystemParts<T>
 {
     using Triplet = Eigen::Triplet<T>;
     using SparseMatrix = Eigen::SparseMatrix<T>;
 
-    // Map selected edge to closest XY axis. Use sign to select direction.
-    auto pinVec = p1->pos - p0->pos;
-    auto dist = norm(pinVec);
-    pinVec /= dist;
-    p0->pos = {T(0), T(0), T(0)};
-    auto maxElem = std::max_element(pinVec.begin(), pinVec.end());
-    auto maxAxis = std::distance(pinVec.begin(), maxElem);
-    dist = std::copysign(dist, *maxElem);
-    if (maxAxis == 0) {
-        p1->pos = {dist, T(0), T(0)};
-    } else {
-        p1->pos = {T(0), dist, T(0)};
-    }
-
     const auto numFaces = mesh->num_faces();
     const auto numVerts = mesh->num_vertices();
-    constexpr std::size_t numFixed = 2;
+    const auto numFixed = pins.size();
     const auto numFree = numVerts - numFixed;
+
+    // Pin index → slot (0-based position within the PinMap).
+    std::unordered_map<std::size_t, std::size_t> pinSlot;
+    pinSlot.reserve(numFixed);
+    for (std::size_t s = 0; s < numFixed; ++s) {
+        pinSlot.emplace(pins[s].first, s);
+    }
+
+    // Write pin UVs into the mesh and into bFixed.
+    std::vector<Triplet> tripletsB;
+    tripletsB.reserve(2 * numFixed);
+    for (std::size_t s = 0; s < numFixed; ++s) {
+        const auto& [vIdx, uv] = pins[s];
+        auto v = mesh->vertex(vIdx);
+        v->pos = {uv[0], uv[1], T(0)};
+        tripletsB.emplace_back(2 * s, 0, uv[0]);
+        tripletsB.emplace_back(2 * s + 1, 0, uv[1]);
+    }
+    SparseMatrix bFixed(2 * numFixed, 1);
+    bFixed.reserve(tripletsB.size());
+    bFixed.setFromTriplets(tripletsB.begin(), tripletsB.end());
 
     // Permutation for free vertices: maps mesh vertex idx → row-pair slot in A.
     std::unordered_map<std::size_t, std::size_t> freeIdxTable;
     freeIdxTable.reserve(numFree);
     for (const auto& v : mesh->vertices()) {
-        if (v == p0 or v == p1) {
+        if (pinSlot.count(v->idx)) {
             continue;
         }
         auto newIdx = freeIdxTable.size();
         freeIdxTable[v->idx] = newIdx;
     }
-
-    // Setup pinned bFixed.
-    std::vector<Triplet> tripletsB;
-    tripletsB.emplace_back(0, 0, p0->pos[0]);
-    tripletsB.emplace_back(1, 0, p0->pos[1]);
-    tripletsB.emplace_back(2, 0, p1->pos[0]);
-    tripletsB.emplace_back(3, 0, p1->pos[1]);
-    SparseMatrix bFixed(2 * numFixed, 1);
-    bFixed.reserve(tripletsB.size());
-    bFixed.setFromTriplets(tripletsB.begin(), tripletsB.end());
 
     // Setup variables matrix. Only solving for free vertices, so pins go in
     // a special matrix.
@@ -99,19 +104,16 @@ auto buildSystem(const typename MeshType::Pointer& mesh, const typename MeshType
 
     // Per-vertex contribution helper (Lévy et al. 2002, Eq. 10).
     // Each vertex contributes a 2×2 conformal block [c, -s; s, c] at its
-    // column. Fixed pins (p0, p1) go into tripletsB; free vertices into
-    // tripletsA.
+    // column. Pin vertices go into tripletsB at columns 2*slot and 2*slot+1;
+    // free vertices into tripletsA.
     auto addContrib = [&](std::size_t row, const auto& e, T c, T s) {
-        if (e->vertex == p0) {
-            tripletsB.emplace_back(row, 0, c);
-            tripletsB.emplace_back(row, 1, -s);
-            tripletsB.emplace_back(row + 1, 0, s);
-            tripletsB.emplace_back(row + 1, 1, c);
-        } else if (e->vertex == p1) {
-            tripletsB.emplace_back(row, 2, c);
-            tripletsB.emplace_back(row, 3, -s);
-            tripletsB.emplace_back(row + 1, 2, s);
-            tripletsB.emplace_back(row + 1, 3, c);
+        auto it = pinSlot.find(e->vertex->idx);
+        if (it != pinSlot.end()) {
+            auto col = 2 * it->second;
+            tripletsB.emplace_back(row, col, c);
+            tripletsB.emplace_back(row, col + 1, -s);
+            tripletsB.emplace_back(row + 1, col, s);
+            tripletsB.emplace_back(row + 1, col + 1, c);
         } else {
             auto freeIdx = freeIdxTable.at(e->vertex->idx);
             tripletsA.emplace_back(row, 2 * freeIdx, c);

--- a/single_include/OpenABF/OpenABF.hpp
+++ b/single_include/OpenABF/OpenABF.hpp
@@ -3133,8 +3133,8 @@ void ValidatePins(const typename MeshType::Pointer& mesh, const PinMap<T>& pins)
  * either index is out of range.
  */
 template <typename T, class MeshType>
-auto AutoPlacePair(const typename MeshType::Pointer& mesh, std::size_t p0Idx, std::size_t p1Idx)
-    -> PinMap<T>
+auto AutoPlacePair(const typename MeshType::Pointer& mesh, std::size_t p0Idx,
+                   std::size_t p1Idx) -> PinMap<T>
 {
     const auto numVerts = mesh->num_vertices();
     if (p0Idx >= numVerts || p1Idx >= numVerts) {

--- a/single_include/OpenABF/OpenABF.hpp
+++ b/single_include/OpenABF/OpenABF.hpp
@@ -3075,6 +3075,8 @@ private:
 
 #include <Eigen/SparseCore>
 
+// #include "OpenABF/Exceptions.hpp"
+
 // #include "OpenABF/Math.hpp"
 
 // #include "OpenABF/Vec.hpp"
@@ -3100,7 +3102,7 @@ using PinMap = std::vector<std::pair<std::size_t, OpenABF::Vec<T, 2>>>;
  * boundary.
  */
 template <typename T, class MeshType>
-void validatePins(const typename MeshType::Pointer& mesh, const PinMap<T>& pins)
+void ValidatePins(const typename MeshType::Pointer& mesh, const PinMap<T>& pins)
 {
     if (pins.size() < 2) {
         throw std::invalid_argument("LSCM: PinMap requires at least 2 pins");
@@ -3131,8 +3133,8 @@ void validatePins(const typename MeshType::Pointer& mesh, const PinMap<T>& pins)
  * either index is out of range.
  */
 template <typename T, class MeshType>
-auto autoPlacePair(const typename MeshType::Pointer& mesh, std::size_t p0Idx,
-                   std::size_t p1Idx) -> PinMap<T>
+auto AutoPlacePair(const typename MeshType::Pointer& mesh, std::size_t p0Idx, std::size_t p1Idx)
+    -> PinMap<T>
 {
     const auto numVerts = mesh->num_vertices();
     if (p0Idx >= numVerts || p1Idx >= numVerts) {
@@ -3152,6 +3154,39 @@ auto autoPlacePair(const typename MeshType::Pointer& mesh, std::size_t p0Idx,
     Vec<T, 2> uv0{T(0), T(0)};
     Vec<T, 2> uv1 = (maxAxis == 0) ? Vec<T, 2>{dist, T(0)} : Vec<T, 2>{T(0), dist};
     return PinMap<T>{{p0Idx, uv0}, {p1Idx, uv1}};
+}
+
+/**
+ * @brief Auto-select two boundary pins and place them via the LSCM
+ * axis-snap convention.
+ *
+ * Picks the first boundary vertex returned by `mesh->vertices_boundary()` as
+ * pin0 and walks the boundary to find an adjacent boundary vertex as pin1.
+ * UVs follow the axis-snap convention applied by `AutoPlacePair`.
+ *
+ * @throws MeshException if the mesh has no boundary vertices, or if no
+ *         boundary-adjacent neighbor is found for the first boundary vertex.
+ */
+template <typename T, class MeshType>
+auto AutoSelectPins(const typename MeshType::Pointer& mesh) -> PinMap<T>
+{
+    auto boundary = mesh->vertices_boundary();
+    if (boundary.empty()) {
+        throw MeshException("LSCM: mesh has no boundary vertices");
+    }
+    auto p0 = boundary.front();
+    auto e = p0->edge;
+    do {
+        if (e->pair->is_boundary()) {
+            break;
+        }
+        e = e->pair->next;
+    } while (e != p0->edge);
+    if (e == p0->edge && !e->pair->is_boundary()) {
+        throw MeshException("LSCM: pinned vertex not on boundary");
+    }
+    auto p1 = e->next->vertex;
+    return AutoPlacePair<T, MeshType>(mesh, p0->idx, p1->idx);
 }
 
 /**
@@ -3185,7 +3220,7 @@ struct SystemParts {
  * The function does NOT auto-place pins — UVs are taken verbatim from the
  * PinMap. Callers that want the LSCM axis-snap convention (origin +
  * dominant-axis placement for an auto-selected pair) compute those UVs
- * themselves via `autoPlacePair` before calling this helper.
+ * themselves via `AutoPlacePair` before calling this helper.
  *
  * Assembly follows Lévy et al. 2002 Eq. 10 using the per-edge `alpha` angles
  * already stored on the mesh.
@@ -3437,7 +3472,7 @@ public:
      * The PinMap must contain at least two unique, in-range vertex indices;
      * `compute()` rejects malformed inputs at solve time.
      */
-    void setPins(PinMap pins)
+    void set_pins(PinMap pins)
     {
         pins_ = std::move(pins);
         legacyPinIndices_.reset();
@@ -3447,10 +3482,10 @@ public:
      * @brief Deprecated: set a pin pair by index using the LSCM axis-snap
      * convention at compute time.
      *
-     * @deprecated Prefer `setPins(PinMap)`. This overload will be removed in
+     * @deprecated Prefer `set_pins(PinMap)`. This overload will be removed in
      * version 3.0.
      */
-    [[deprecated("Use setPins(PinMap); will be removed in 3.0")]] void setPinnedVertices(
+    [[deprecated("Use set_pins(PinMap); will be removed in 3.0")]] void setPinnedVertices(
         std::size_t pin0Idx, std::size_t pin1Idx)
     {
         legacyPinIndices_ = {pin0Idx, pin1Idx};
@@ -3463,7 +3498,7 @@ public:
         if (pins_) {
             Compute(mesh, *pins_);
         } else if (legacyPinIndices_) {
-            ComputeImpl(mesh, detail::lscm::autoPlacePair<T, Mesh>(mesh, legacyPinIndices_->first,
+            ComputeImpl(mesh, detail::lscm::AutoPlacePair<T, Mesh>(mesh, legacyPinIndices_->first,
                                                                    legacyPinIndices_->second));
         } else {
             Compute(mesh);
@@ -3481,7 +3516,10 @@ public:
      * @throws SolverException If matrix cannot be decomposed or if solver fails
      * to find a solution.
      */
-    static void Compute(typename Mesh::Pointer& mesh) { ComputeImpl(mesh, autoSelectPins(mesh)); }
+    static void Compute(typename Mesh::Pointer& mesh)
+    {
+        ComputeImpl(mesh, detail::lscm::AutoSelectPins<T, Mesh>(mesh));
+    }
 
     /**
      * @brief Compute the parameterized mesh with caller-specified pin UVs
@@ -3498,7 +3536,7 @@ public:
      */
     static void Compute(typename Mesh::Pointer& mesh, const PinMap& pins)
     {
-        detail::lscm::validatePins<T, Mesh>(mesh, pins);
+        detail::lscm::ValidatePins<T, Mesh>(mesh, pins);
         ComputeImpl(mesh, pins);
     }
 
@@ -3515,44 +3553,14 @@ public:
     [[deprecated("Use Compute(mesh, PinMap); will be removed in 3.0")]] static void Compute(
         typename Mesh::Pointer& mesh, std::size_t pin0Idx, std::size_t pin1Idx)
     {
-        ComputeImpl(mesh, detail::lscm::autoPlacePair<T, Mesh>(mesh, pin0Idx, pin1Idx));
+        ComputeImpl(mesh, detail::lscm::AutoPlacePair<T, Mesh>(mesh, pin0Idx, pin1Idx));
     }
 
 private:
-    /** Optional explicit pin set configured via `setPins()`. */
+    /** Optional explicit pin set configured via `set_pins()`. */
     std::optional<PinMap> pins_;
     /** Deprecated: legacy two-pin index pair set via `setPinnedVertices`. */
     std::optional<std::pair<std::size_t, std::size_t>> legacyPinIndices_;
-
-    /** Walk the boundary to pick the default pin pair. */
-    static auto selectBoundaryPair(const typename Mesh::Pointer& mesh)
-        -> std::pair<typename Mesh::VertPtr, typename Mesh::VertPtr>
-    {
-        auto boundary = mesh->vertices_boundary();
-        if (boundary.empty()) {
-            throw MeshException("AngleBasedLSCM: mesh has no boundary vertices");
-        }
-        auto p0 = boundary.front();
-        auto e = p0->edge;
-        do {
-            if (e->pair->is_boundary()) {
-                break;
-            }
-            e = e->pair->next;
-        } while (e != p0->edge);
-        if (e == p0->edge and not e->pair->is_boundary()) {
-            throw MeshException("Pinned vertex not on boundary");
-        }
-        auto p1 = e->next->vertex;
-        return {p0, p1};
-    }
-
-    /** Auto-select two boundary pins and place them via the LSCM axis-snap convention. */
-    static auto autoSelectPins(const typename Mesh::Pointer& mesh) -> PinMap
-    {
-        auto [p0, p1] = selectBoundaryPair(mesh);
-        return detail::lscm::autoPlacePair<T, Mesh>(mesh, p0->idx, p1->idx);
-    }
 
     /**
      * @brief Core solver: build the LSCM system from the PinMap, solve for free
@@ -4590,7 +4598,7 @@ public:
     /**
      * @brief Set the explicit pin set used by `compute()`
      */
-    void setPins(PinMap pins)
+    void set_pins(PinMap pins)
     {
         pins_ = std::move(pins);
         legacyPinIndices_.reset();
@@ -4600,10 +4608,10 @@ public:
      * @brief Deprecated: set a pin pair by index using the LSCM axis-snap
      * convention at compute time.
      *
-     * @deprecated Prefer `setPins(PinMap)`. This overload will be removed in
+     * @deprecated Prefer `set_pins(PinMap)`. This overload will be removed in
      * version 3.0.
      */
-    [[deprecated("Use setPins(PinMap); will be removed in 3.0")]] void setPinnedVertices(
+    [[deprecated("Use set_pins(PinMap); will be removed in 3.0")]] void setPinnedVertices(
         std::size_t pin0Idx, std::size_t pin1Idx)
     {
         legacyPinIndices_ = {pin0Idx, pin1Idx};
@@ -4631,7 +4639,7 @@ public:
     /**
      * @brief Compute parameterization using instance configuration
      *
-     * If `setPins()` was called, uses the supplied PinMap. Otherwise, if the
+     * If `set_pins()` was called, uses the supplied PinMap. Otherwise, if the
      * deprecated `setPinnedVertices()` was called, builds a PinMap from those
      * indices via the LSCM axis-snap convention. Otherwise auto-selects two
      * boundary vertices using the same logic as `Compute(mesh)`.
@@ -4644,12 +4652,12 @@ public:
         PinMap pins;
         if (pins_) {
             pins = *pins_;
-            detail::lscm::validatePins<T, Mesh>(mesh, pins);
+            detail::lscm::ValidatePins<T, Mesh>(mesh, pins);
         } else if (legacyPinIndices_) {
-            pins = detail::lscm::autoPlacePair<T, Mesh>(mesh, legacyPinIndices_->first,
+            pins = detail::lscm::AutoPlacePair<T, Mesh>(mesh, legacyPinIndices_->first,
                                                         legacyPinIndices_->second);
         } else {
-            pins = autoSelectPins(mesh);
+            pins = detail::lscm::AutoSelectPins<T, Mesh>(mesh);
         }
         ComputeImpl(mesh, pins, levelRatio_, minCoarseVertices_);
     }
@@ -4664,7 +4672,10 @@ public:
      *         fails) or the mesh is otherwise invalid
      * @throws SolverException if any hierarchy level fails to solve
      */
-    static void Compute(typename Mesh::Pointer& mesh) { ComputeImpl(mesh, autoSelectPins(mesh)); }
+    static void Compute(typename Mesh::Pointer& mesh)
+    {
+        ComputeImpl(mesh, detail::lscm::AutoSelectPins<T, Mesh>(mesh));
+    }
 
     /**
      * @brief Compute with caller-specified pin UVs
@@ -4675,7 +4686,7 @@ public:
      */
     static void Compute(typename Mesh::Pointer& mesh, const PinMap& pins)
     {
-        detail::lscm::validatePins<T, Mesh>(mesh, pins);
+        detail::lscm::ValidatePins<T, Mesh>(mesh, pins);
         ComputeImpl(mesh, pins);
     }
 
@@ -4691,39 +4702,10 @@ public:
     [[deprecated("Use Compute(mesh, PinMap); will be removed in 3.0")]] static void Compute(
         typename Mesh::Pointer& mesh, std::size_t pin0Idx, std::size_t pin1Idx)
     {
-        ComputeImpl(mesh, detail::lscm::autoPlacePair<T, Mesh>(mesh, pin0Idx, pin1Idx));
+        ComputeImpl(mesh, detail::lscm::AutoPlacePair<T, Mesh>(mesh, pin0Idx, pin1Idx));
     }
 
 private:
-    /** Walk the boundary to pick the default pin pair as (idx, idx). */
-    static auto selectBoundaryPair(const typename Mesh::Pointer& mesh)
-        -> std::pair<std::size_t, std::size_t>
-    {
-        auto boundary = mesh->vertices_boundary();
-        if (boundary.empty()) {
-            throw MeshException("HierarchicalLSCM: mesh has no boundary vertices");
-        }
-        auto v0 = boundary.front();
-        auto e = v0->edge;
-        do {
-            if (e->pair->is_boundary()) {
-                break;
-            }
-            e = e->pair->next;
-        } while (e != v0->edge);
-        if (e == v0->edge && !e->pair->is_boundary()) {
-            throw MeshException("Pinned vertex not on boundary");
-        }
-        return {v0->idx, e->next->vertex->idx};
-    }
-
-    /** Auto-select two boundary pins and place them via axis-snap. */
-    static auto autoSelectPins(const typename Mesh::Pointer& mesh) -> PinMap
-    {
-        auto [p0Idx, p1Idx] = selectBoundaryPair(mesh);
-        return detail::lscm::autoPlacePair<T, Mesh>(mesh, p0Idx, p1Idx);
-    }
-
     /**
      * @brief Copy edge angles from the original mesh to a level mesh
      *
@@ -4818,7 +4800,7 @@ private:
         }
     }
 
-    /** Optional explicit pin set configured via `setPins()`. */
+    /** Optional explicit pin set configured via `set_pins()`. */
     std::optional<PinMap> pins_;
     /** Deprecated: legacy two-pin index pair set via `setPinnedVertices`. */
     std::optional<std::pair<std::size_t, std::size_t>> legacyPinIndices_;

--- a/single_include/OpenABF/OpenABF.hpp
+++ b/single_include/OpenABF/OpenABF.hpp
@@ -3131,8 +3131,8 @@ void validatePins(const typename MeshType::Pointer& mesh, const PinMap<T>& pins)
  * either index is out of range.
  */
 template <typename T, class MeshType>
-auto autoPlacePair(const typename MeshType::Pointer& mesh, std::size_t p0Idx, std::size_t p1Idx)
-    -> PinMap<T>
+auto autoPlacePair(const typename MeshType::Pointer& mesh, std::size_t p0Idx,
+                   std::size_t p1Idx) -> PinMap<T>
 {
     const auto numVerts = mesh->num_vertices();
     if (p0Idx >= numVerts || p1Idx >= numVerts) {

--- a/single_include/OpenABF/OpenABF.hpp
+++ b/single_include/OpenABF/OpenABF.hpp
@@ -3039,8 +3039,13 @@ private:
 // #include "OpenABF/AngleBasedLSCM.hpp"
 
 
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <iterator>
 #include <optional>
 #include <type_traits>
+#include <unordered_set>
 #include <utility>
 
 #include <Eigen/IterativeLinearSolvers>
@@ -3052,6 +3057,8 @@ private:
 
 // #include "OpenABF/Math.hpp"
 
+// #include "OpenABF/Vec.hpp"
+
 // #include "OpenABF/detail/LSCMSystem.hpp"
 
 
@@ -3059,20 +3066,29 @@ private:
 #include <array>
 #include <cmath>
 #include <cstddef>
-#include <iterator>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 
 #include <Eigen/SparseCore>
+
+// #include "OpenABF/Vec.hpp"
+
 
 namespace OpenABF::detail::lscm
 {
 
 /**
- * @brief Outputs of `buildSystem`: the LSCM least-squares system for a mesh
- *        with two pinned vertices.
+ * @brief Per-pin entry: (mesh vertex index, target UV).
  *
- * @tparam T Floating-point type
+ * Shared by `AngleBasedLSCM::PinMap` and `HierarchicalLSCM::PinMap`.
+ */
+template <typename T>
+using PinMap = std::vector<std::pair<std::size_t, OpenABF::Vec<T, 2>>>;
+
+/**
+ * @brief Outputs of `buildSystem`: the LSCM least-squares system for a mesh
+ *        with N pinned vertices (N ≥ 2).
  *
  * Layout: `A` is `(2·numFaces) × (2·numFree)`, `b` is `(2·numFaces) × 1`,
  * `freeIdxTable` maps `vertex->idx` to a row-pair index in `A`/`x` (so a free
@@ -3090,62 +3106,59 @@ struct SystemParts {
 };
 
 /**
- * @brief Build the LSCM sparse system for a mesh with two pinned vertices.
+ * @brief Build the LSCM sparse system for a mesh with N pinned vertices.
  *
- * Mutates the mesh: places `p0` at the UV origin and `p1` on whichever XY
- * axis its displacement from `p0` has the largest magnitude — same pin
- * placement convention used by `AngleBasedLSCM::ComputeImpl` and
- * `HierarchicalLSCM::solveLSCMLevel`.
+ * Mutates the mesh: each pinned vertex's `pos` is overwritten with `{uv[0],
+ * uv[1], 0}` (the caller's chosen UV). The function does NOT auto-place pins
+ * — UVs are taken verbatim from the PinMap. Callers that want the LSCM
+ * axis-snap convention (origin + dominant-axis placement for an auto-selected
+ * pair) compute those UVs themselves before calling this helper.
  *
  * Assembly follows Lévy et al. 2002 Eq. 10 using the per-edge `alpha` angles
  * already stored on the mesh.
  */
 template <typename T, class MeshType>
-auto buildSystem(const typename MeshType::Pointer& mesh, const typename MeshType::VertPtr& p0,
-                 const typename MeshType::VertPtr& p1) -> SystemParts<T>
+auto buildSystem(const typename MeshType::Pointer& mesh, const PinMap<T>& pins) -> SystemParts<T>
 {
     using Triplet = Eigen::Triplet<T>;
     using SparseMatrix = Eigen::SparseMatrix<T>;
 
-    // Map selected edge to closest XY axis. Use sign to select direction.
-    auto pinVec = p1->pos - p0->pos;
-    auto dist = norm(pinVec);
-    pinVec /= dist;
-    p0->pos = {T(0), T(0), T(0)};
-    auto maxElem = std::max_element(pinVec.begin(), pinVec.end());
-    auto maxAxis = std::distance(pinVec.begin(), maxElem);
-    dist = std::copysign(dist, *maxElem);
-    if (maxAxis == 0) {
-        p1->pos = {dist, T(0), T(0)};
-    } else {
-        p1->pos = {T(0), dist, T(0)};
-    }
-
     const auto numFaces = mesh->num_faces();
     const auto numVerts = mesh->num_vertices();
-    constexpr std::size_t numFixed = 2;
+    const auto numFixed = pins.size();
     const auto numFree = numVerts - numFixed;
+
+    // Pin index → slot (0-based position within the PinMap).
+    std::unordered_map<std::size_t, std::size_t> pinSlot;
+    pinSlot.reserve(numFixed);
+    for (std::size_t s = 0; s < numFixed; ++s) {
+        pinSlot.emplace(pins[s].first, s);
+    }
+
+    // Write pin UVs into the mesh and into bFixed.
+    std::vector<Triplet> tripletsB;
+    tripletsB.reserve(2 * numFixed);
+    for (std::size_t s = 0; s < numFixed; ++s) {
+        const auto& [vIdx, uv] = pins[s];
+        auto v = mesh->vertex(vIdx);
+        v->pos = {uv[0], uv[1], T(0)};
+        tripletsB.emplace_back(2 * s, 0, uv[0]);
+        tripletsB.emplace_back(2 * s + 1, 0, uv[1]);
+    }
+    SparseMatrix bFixed(2 * numFixed, 1);
+    bFixed.reserve(tripletsB.size());
+    bFixed.setFromTriplets(tripletsB.begin(), tripletsB.end());
 
     // Permutation for free vertices: maps mesh vertex idx → row-pair slot in A.
     std::unordered_map<std::size_t, std::size_t> freeIdxTable;
     freeIdxTable.reserve(numFree);
     for (const auto& v : mesh->vertices()) {
-        if (v == p0 or v == p1) {
+        if (pinSlot.count(v->idx)) {
             continue;
         }
         auto newIdx = freeIdxTable.size();
         freeIdxTable[v->idx] = newIdx;
     }
-
-    // Setup pinned bFixed.
-    std::vector<Triplet> tripletsB;
-    tripletsB.emplace_back(0, 0, p0->pos[0]);
-    tripletsB.emplace_back(1, 0, p0->pos[1]);
-    tripletsB.emplace_back(2, 0, p1->pos[0]);
-    tripletsB.emplace_back(3, 0, p1->pos[1]);
-    SparseMatrix bFixed(2 * numFixed, 1);
-    bFixed.reserve(tripletsB.size());
-    bFixed.setFromTriplets(tripletsB.begin(), tripletsB.end());
 
     // Setup variables matrix. Only solving for free vertices, so pins go in
     // a special matrix.
@@ -3154,19 +3167,16 @@ auto buildSystem(const typename MeshType::Pointer& mesh, const typename MeshType
 
     // Per-vertex contribution helper (Lévy et al. 2002, Eq. 10).
     // Each vertex contributes a 2×2 conformal block [c, -s; s, c] at its
-    // column. Fixed pins (p0, p1) go into tripletsB; free vertices into
-    // tripletsA.
+    // column. Pin vertices go into tripletsB at columns 2*slot and 2*slot+1;
+    // free vertices into tripletsA.
     auto addContrib = [&](std::size_t row, const auto& e, T c, T s) {
-        if (e->vertex == p0) {
-            tripletsB.emplace_back(row, 0, c);
-            tripletsB.emplace_back(row, 1, -s);
-            tripletsB.emplace_back(row + 1, 0, s);
-            tripletsB.emplace_back(row + 1, 1, c);
-        } else if (e->vertex == p1) {
-            tripletsB.emplace_back(row, 2, c);
-            tripletsB.emplace_back(row, 3, -s);
-            tripletsB.emplace_back(row + 1, 2, s);
-            tripletsB.emplace_back(row + 1, 3, c);
+        auto it = pinSlot.find(e->vertex->idx);
+        if (it != pinSlot.end()) {
+            auto col = 2 * it->second;
+            tripletsB.emplace_back(row, col, c);
+            tripletsB.emplace_back(row, col + 1, -s);
+            tripletsB.emplace_back(row + 1, col, s);
+            tripletsB.emplace_back(row + 1, col + 1, c);
         } else {
             auto freeIdx = freeIdxTable.at(e->vertex->idx);
             tripletsA.emplace_back(row, 2 * freeIdx, c);
@@ -3342,17 +3352,48 @@ public:
     /** @brief Mesh type alias */
     using Mesh = MeshType;
 
-    /** @brief Set the pinned vertex indices used by compute() */
-    void setPinnedVertices(std::size_t pin0Idx, std::size_t pin1Idx)
+    /**
+     * @brief Per-pin entry: (mesh vertex index, target UV).
+     *
+     * A `PinMap` of size N ≥ 2 specifies an explicit LSCM pin set; each pinned
+     * vertex's final UV equals its entry in the map.
+     */
+    using PinMap = detail::lscm::PinMap<T>;
+
+    /**
+     * @brief Set the explicit pin set used by `compute()`
+     *
+     * The PinMap must contain at least two unique, in-range vertex indices;
+     * `compute()` rejects malformed inputs at solve time.
+     */
+    void setPins(PinMap pins)
     {
-        pinnedVertices_ = {pin0Idx, pin1Idx};
+        pins_ = std::move(pins);
+        legacyPinIndices_.reset();
+    }
+
+    /**
+     * @brief Deprecated: set a pin pair by index using the LSCM axis-snap
+     * convention at compute time.
+     *
+     * @deprecated Prefer `setPins(PinMap)`. This overload will be removed in
+     * version 3.0.
+     */
+    [[deprecated("Use setPins(PinMap); will be removed in 3.0")]] void setPinnedVertices(
+        std::size_t pin0Idx, std::size_t pin1Idx)
+    {
+        legacyPinIndices_ = {pin0Idx, pin1Idx};
+        pins_.reset();
     }
 
     /** @copydoc AngleBasedLSCM::Compute() */
     void compute(typename Mesh::Pointer& mesh) const
     {
-        if (pinnedVertices_) {
-            Compute(mesh, pinnedVertices_->first, pinnedVertices_->second);
+        if (pins_) {
+            Compute(mesh, *pins_);
+        } else if (legacyPinIndices_) {
+            ComputeImpl(mesh,
+                        autoPlacePair(mesh, legacyPinIndices_->first, legacyPinIndices_->second));
         } else {
             Compute(mesh);
         }
@@ -3362,16 +3403,65 @@ public:
      * @brief Compute the parameterized mesh using automatic pin selection
      *
      * Selects the first boundary vertex and its boundary-edge neighbor as
-     * pinned vertices.
+     * pinned vertices, placing pin0 at the UV origin and pin1 at distance
+     * `|p1 - p0|` along the dominant world-axis of `(p1 - p0)`.
      *
-     * @throws MeshException If pinned vertex is not on boundary.
+     * @throws MeshException If pin selection fails (no boundary vertices).
      * @throws SolverException If matrix cannot be decomposed or if solver fails
      * to find a solution.
      */
-    static void Compute(typename Mesh::Pointer& mesh)
+    static void Compute(typename Mesh::Pointer& mesh) { ComputeImpl(mesh, autoSelectPins(mesh)); }
+
+    /**
+     * @brief Compute the parameterized mesh with caller-specified pin UVs
+     *
+     * @param mesh Triangle mesh whose vertex positions will be overwritten with
+     * computed 2D UV coordinates (z component set to 0).
+     * @param pins Sequence of (vertex index, target UV) pairs. Must contain at
+     * least two unique, in-range vertex indices. Each pinned vertex's final UV
+     * equals the supplied target verbatim.
+     * @throws std::invalid_argument If `pins` has fewer than two entries, a
+     * duplicate index, or an out-of-range index.
+     * @throws SolverException If matrix cannot be decomposed or if solver fails
+     * to find a solution.
+     */
+    static void Compute(typename Mesh::Pointer& mesh, const PinMap& pins)
     {
-        // Pinned vertex selection: first boundary vertex + boundary-edge neighbor
-        auto p0 = mesh->vertices_boundary().front();
+        validatePins(mesh, pins);
+        ComputeImpl(mesh, pins);
+    }
+
+    /**
+     * @brief Deprecated: compute with an explicit pin pair by index.
+     *
+     * Builds a 2-entry PinMap using the LSCM axis-snap convention (pin0 at the
+     * UV origin, pin1 on the dominant world-axis of `(p1 - p0)`) and
+     * dispatches to the PinMap path.
+     *
+     * @deprecated Prefer `Compute(mesh, PinMap)`. This overload will be
+     * removed in version 3.0.
+     */
+    [[deprecated("Use Compute(mesh, PinMap); will be removed in 3.0")]] static void Compute(
+        typename Mesh::Pointer& mesh, std::size_t pin0Idx, std::size_t pin1Idx)
+    {
+        ComputeImpl(mesh, autoPlacePair(mesh, pin0Idx, pin1Idx));
+    }
+
+private:
+    /** Optional explicit pin set configured via `setPins()`. */
+    std::optional<PinMap> pins_;
+    /** Deprecated: legacy two-pin index pair set via `setPinnedVertices`. */
+    std::optional<std::pair<std::size_t, std::size_t>> legacyPinIndices_;
+
+    /** Walk the boundary to pick the default pin pair. */
+    static auto selectBoundaryPair(const typename Mesh::Pointer& mesh)
+        -> std::pair<typename Mesh::VertPtr, typename Mesh::VertPtr>
+    {
+        auto boundary = mesh->vertices_boundary();
+        if (boundary.empty()) {
+            throw MeshException("AngleBasedLSCM: mesh has no boundary vertices");
+        }
+        auto p0 = boundary.front();
         auto e = p0->edge;
         do {
             if (e->pair->is_boundary()) {
@@ -3383,47 +3473,85 @@ public:
             throw MeshException("Pinned vertex not on boundary");
         }
         auto p1 = e->next->vertex;
-        ComputeImpl(mesh, p0, p1);
+        return {p0, p1};
     }
 
     /**
-     * @brief Compute the parameterized mesh with explicit pinned vertex indices
+     * @brief Build a 2-entry PinMap from explicit indices using the LSCM
+     * axis-snap convention.
      *
-     * @param mesh Triangle mesh whose vertex positions will be overwritten with
-     * computed 2D UV coordinates (z component set to 0).
-     * @param pin0Idx Index of the first pinned vertex (placed at the UV origin)
-     * @param pin1Idx Index of the second pinned vertex (placed on the nearest axis)
-     * @throws SolverException If matrix cannot be decomposed or if solver fails
-     * to find a solution.
+     * pin0 at `{0, 0}`, pin1 at signed distance `|p1 - p0|` on whichever world
+     * axis the `(p1 - p0)` vector has the largest magnitude.
      */
-    static void Compute(typename Mesh::Pointer& mesh, std::size_t pin0Idx, std::size_t pin1Idx)
+    static auto autoPlacePair(const typename Mesh::Pointer& mesh, std::size_t p0Idx,
+                              std::size_t p1Idx) -> PinMap
     {
-        ComputeImpl(mesh, mesh->vertex(pin0Idx), mesh->vertex(pin1Idx));
+        auto p0 = mesh->vertex(p0Idx);
+        auto p1 = mesh->vertex(p1Idx);
+        auto pinVec = p1->pos - p0->pos;
+        auto dist = norm(pinVec);
+        pinVec /= dist;
+        auto maxElem = std::max_element(pinVec.begin(), pinVec.end());
+        auto maxAxis = std::distance(pinVec.begin(), maxElem);
+        dist = std::copysign(dist, *maxElem);
+        Vec<T, 2> uv0{T(0), T(0)};
+        Vec<T, 2> uv1 = (maxAxis == 0) ? Vec<T, 2>{dist, T(0)} : Vec<T, 2>{T(0), dist};
+        return PinMap{{p0Idx, uv0}, {p1Idx, uv1}};
     }
 
-private:
-    /** Optional explicit pin pair set via setPinnedVertices() */
-    std::optional<std::pair<std::size_t, std::size_t>> pinnedVertices_;
+    /**
+     * @brief Auto-select two boundary pins and place them via the LSCM
+     * axis-snap convention.
+     */
+    static auto autoSelectPins(const typename Mesh::Pointer& mesh) -> PinMap
+    {
+        auto [p0, p1] = selectBoundaryPair(mesh);
+        return autoPlacePair(mesh, p0->idx, p1->idx);
+    }
+
+    /** Validate that the user's PinMap is well-formed for this mesh. */
+    static void validatePins(const typename Mesh::Pointer& mesh, const PinMap& pins)
+    {
+        if (pins.size() < 2) {
+            throw std::invalid_argument("AngleBasedLSCM: PinMap requires at least 2 pins");
+        }
+        auto numVerts = mesh->num_vertices();
+        std::unordered_set<std::size_t> seen;
+        seen.reserve(pins.size());
+        for (const auto& [vIdx, uv] : pins) {
+            if (vIdx >= numVerts) {
+                throw std::invalid_argument("AngleBasedLSCM: PinMap vertex index out of range");
+            }
+            if (!seen.insert(vIdx).second) {
+                throw std::invalid_argument("AngleBasedLSCM: PinMap has duplicate vertex index");
+            }
+        }
+    }
 
     /**
-     * @brief Core solver: place p0/p1 on the UV axes then solve for free vertices
+     * @brief Core solver: build the LSCM system from the PinMap, solve for free
+     * vertices, and write UVs back to the mesh.
      */
-    static void ComputeImpl(typename Mesh::Pointer& mesh, const typename Mesh::VertPtr& p0,
-                            const typename Mesh::VertPtr& p1)
+    static void ComputeImpl(typename Mesh::Pointer& mesh, const PinMap& pins)
     {
         using SparseMatrix = Eigen::SparseMatrix<T>;
         using DenseMatrix = Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>;
 
         // Pin placement + LSCM system assembly (shared with HierarchicalLSCM)
-        auto parts = detail::lscm::buildSystem<T, Mesh>(mesh, p0, p1);
+        auto parts = detail::lscm::buildSystem<T, Mesh>(mesh, pins);
 
         // Solve for x
         auto x = detail::SolveLeastSquares<SparseMatrix, DenseMatrix, Solver>(parts.A, parts.b);
 
-        // Assign solution to UV coordinates
-        // Pins are already updated by buildSystem, so these are free vertices
+        // Assign solution to free vertices. Pin vertices are already at their
+        // target UVs (written by buildSystem).
+        std::unordered_set<std::size_t> pinIdx;
+        pinIdx.reserve(pins.size());
+        for (const auto& [vIdx, uv] : pins) {
+            pinIdx.insert(vIdx);
+        }
         for (const auto& v : mesh->vertices()) {
-            if (v == p0 or v == p1) {
+            if (pinIdx.count(v->idx)) {
                 continue;
             }
             auto newIdx = 2 * parts.freeIdxTable.at(v->idx);
@@ -3435,6 +3563,7 @@ private:
 };
 
 }  // namespace OpenABF
+
 // #include "OpenABF/HierarchicalLSCM.hpp"
 
 
@@ -3558,7 +3687,7 @@ class DecimationMesh
 public:
     /** Build from a HalfEdgeMesh */
     template <class MeshPtr>
-    void build(const MeshPtr& mesh, std::size_t pin0, std::size_t pin1)
+    void build(const MeshPtr& mesh, const std::vector<std::size_t>& pinIndices)
     {
         auto nv = mesh->num_vertices();
         auto nf = mesh->num_faces();
@@ -3569,8 +3698,9 @@ public:
         isPinned_.assign(nv, false);
         quadrics_.resize(nv);
 
-        isPinned_[pin0] = true;
-        isPinned_[pin1] = true;
+        for (auto idx : pinIndices) {
+            isPinned_[idx] = true;
+        }
 
         for (const auto& v : mesh->vertices()) {
             positions_[v->idx] = v->pos;
@@ -4085,12 +4215,12 @@ private:
  * the collapse records needed for prolongation (ordered from finest to coarsest).
  */
 template <typename T, class MeshPtr>
-auto buildHierarchy(const MeshPtr& mesh, std::size_t pin0, std::size_t pin1, std::size_t levelRatio,
-                    std::size_t minCoarseVerts)
+auto buildHierarchy(const MeshPtr& mesh, const std::vector<std::size_t>& pinIndices,
+                    std::size_t levelRatio, std::size_t minCoarseVerts)
     -> std::pair<std::vector<HierarchyLevel<T>>, std::vector<std::vector<CollapseRecord<T>>>>
 {
     DecimationMesh<T> dmesh;
-    dmesh.build(mesh, pin0, pin1);
+    dmesh.build(mesh, pinIndices);
 
     // Finest level snapshot
     std::vector<HierarchyLevel<T>> levels;
@@ -4236,8 +4366,8 @@ auto prolongateUVs(UVVector<T> uvs, const std::vector<CollapseRecord<T>>& collap
  */
 template <typename T, class SolverType>
 auto solveLSCMLevel(const typename HalfEdgeMesh<T>::Pointer& levelMesh,
-                    const detail::hlscm::HierarchyLevel<T>& level, std::size_t origPin0,
-                    std::size_t origPin1, std::size_t origVertCount,
+                    const detail::hlscm::HierarchyLevel<T>& level,
+                    const detail::lscm::PinMap<T>& origPins, std::size_t origVertCount,
                     const UVVector<T>* initialGuess) -> UVVector<T>
 {
     using SparseMatrix = Eigen::SparseMatrix<T>;
@@ -4245,18 +4375,23 @@ auto solveLSCMLevel(const typename HalfEdgeMesh<T>::Pointer& levelMesh,
     using Mesh = HalfEdgeMesh<T>;
 
     auto numVerts = levelMesh->num_vertices();
-    constexpr std::size_t numFixed = 2;
+    auto numFixed = origPins.size();
     auto numFree = numVerts - numFixed;
 
-    // Map original pin indices to level-local indices. Pins are guaranteed
+    // Map each original pin idx to its level-local idx. Pins are guaranteed
     // to survive every decimation level so the unwrap is safe.
-    auto localPin0 = *level.originalToLocal[origPin0];
-    auto localPin1 = *level.originalToLocal[origPin1];
-    auto p0 = levelMesh->vertex(localPin0);
-    auto p1 = levelMesh->vertex(localPin1);
+    detail::lscm::PinMap<T> localPins;
+    localPins.reserve(numFixed);
+    std::unordered_set<std::size_t> localPinIdx;
+    localPinIdx.reserve(numFixed);
+    for (const auto& [origIdx, uv] : origPins) {
+        auto localIdx = *level.originalToLocal[origIdx];
+        localPins.emplace_back(localIdx, uv);
+        localPinIdx.insert(localIdx);
+    }
 
     // Pin placement + LSCM system assembly (shared with AngleBasedLSCM)
-    auto parts = detail::lscm::buildSystem<T, Mesh>(levelMesh, p0, p1);
+    auto parts = detail::lscm::buildSystem<T, Mesh>(levelMesh, localPins);
     auto& A = parts.A;
     auto& b = parts.b;
     auto& freeIdxTable = parts.freeIdxTable;
@@ -4268,7 +4403,7 @@ auto solveLSCMLevel(const typename HalfEdgeMesh<T>::Pointer& levelMesh,
     auto buildInitialGuess = [&]() -> DenseMatrix {
         DenseMatrix x0 = DenseMatrix::Zero(2 * numFree, 1);
         for (const auto& v : levelMesh->vertices()) {
-            if (v == p0 || v == p1) {
+            if (localPinIdx.count(v->idx)) {
                 continue;
             }
             auto freeIdx = freeIdxTable.at(v->idx);
@@ -4339,10 +4474,11 @@ auto solveLSCMLevel(const typename HalfEdgeMesh<T>::Pointer& levelMesh,
     // present at this level remain nullopt; they will be filled in by
     // prolongation when undoing collapses at finer levels.
     UVVector<T> uvs(origVertCount);
-    uvs[level.localToOriginal[p0->idx]] = Vec<T, 2>(p0->pos[0], p0->pos[1]);
-    uvs[level.localToOriginal[p1->idx]] = Vec<T, 2>(p1->pos[0], p1->pos[1]);
+    for (const auto& [origIdx, uv] : origPins) {
+        uvs[origIdx] = uv;
+    }
     for (const auto& v : levelMesh->vertices()) {
-        if (v == p0 || v == p1) {
+        if (localPinIdx.count(v->idx)) {
             continue;
         }
         auto freeIdx = 2 * freeIdxTable.at(v->idx);
@@ -4405,10 +4541,36 @@ public:
     /** @brief Mesh type alias */
     using Mesh = MeshType;
 
-    /** @brief Set the pinned vertex indices used by compute() */
-    void setPinnedVertices(std::size_t pin0Idx, std::size_t pin1Idx)
+    /**
+     * @brief Per-pin entry: (mesh vertex index, target UV).
+     *
+     * A PinMap of size N ≥ 2 specifies an explicit LSCM pin set. Each pin
+     * survives every decimation level — `DecimationMesh::tryCollapse` rejects
+     * any collapse that would remove a pinned vertex.
+     */
+    using PinMap = detail::lscm::PinMap<T>;
+
+    /**
+     * @brief Set the explicit pin set used by `compute()`
+     */
+    void setPins(PinMap pins)
     {
-        pinnedVertices_ = {pin0Idx, pin1Idx};
+        pins_ = std::move(pins);
+        legacyPinIndices_.reset();
+    }
+
+    /**
+     * @brief Deprecated: set a pin pair by index using the LSCM axis-snap
+     * convention at compute time.
+     *
+     * @deprecated Prefer `setPins(PinMap)`. This overload will be removed in
+     * version 3.0.
+     */
+    [[deprecated("Use setPins(PinMap); will be removed in 3.0")]] void setPinnedVertices(
+        std::size_t pin0Idx, std::size_t pin1Idx)
+    {
+        legacyPinIndices_ = {pin0Idx, pin1Idx};
+        pins_.reset();
     }
 
     /** @brief Set the vertex ratio between consecutive hierarchy levels (default: 10) */
@@ -4432,55 +4594,71 @@ public:
     /**
      * @brief Compute parameterization using instance configuration
      *
-     * Uses the pinned vertices, level ratio, and minimum coarse vertices
-     * configured via `setPinnedVertices()`, `setLevelRatio()`, and
-     * `setMinCoarseVertices()`. If no pins are set, selects them automatically
-     * using the same boundary-walk logic as `Compute(mesh)`.
+     * If `setPins()` was called, uses the supplied PinMap. Otherwise, if the
+     * deprecated `setPinnedVertices()` was called, builds a PinMap from those
+     * indices via the LSCM axis-snap convention. Otherwise auto-selects two
+     * boundary vertices using the same logic as `Compute(mesh)`.
      *
      * @throws MeshException if pin selection fails (no boundary vertices)
      * @throws SolverException if any hierarchy level fails to solve
      */
     void compute(typename Mesh::Pointer& mesh) const
     {
-        std::size_t p0, p1;
-        if (pinnedVertices_) {
-            p0 = pinnedVertices_->first;
-            p1 = pinnedVertices_->second;
+        PinMap pins;
+        if (pins_) {
+            pins = *pins_;
+        } else if (legacyPinIndices_) {
+            pins = autoPlacePair(mesh, legacyPinIndices_->first, legacyPinIndices_->second);
         } else {
-            AutoSelectPins(mesh, p0, p1);
+            pins = autoSelectPins(mesh);
         }
-        ComputeImpl(mesh, p0, p1, levelRatio_, minCoarseVertices_);
+        ComputeImpl(mesh, pins, levelRatio_, minCoarseVertices_);
     }
 
     /**
      * @brief Compute with automatic pin selection
      *
-     * Selects pins identically to AngleBasedLSCM::Compute().
+     * Selects pins identically to AngleBasedLSCM::Compute() — first boundary
+     * vertex and its boundary-edge neighbor, placed via LSCM axis-snap.
      *
      * @throws MeshException if the mesh has no boundary vertices (pin selection
      *         fails) or the mesh is otherwise invalid
      * @throws SolverException if any hierarchy level fails to solve
      */
-    static void Compute(typename Mesh::Pointer& mesh)
+    static void Compute(typename Mesh::Pointer& mesh) { ComputeImpl(mesh, autoSelectPins(mesh)); }
+
+    /**
+     * @brief Compute with caller-specified pin UVs
+     *
+     * @throws std::invalid_argument If `pins` has fewer than two entries, a
+     * duplicate index, or an out-of-range index.
+     * @throws SolverException If any hierarchy level fails to solve.
+     */
+    static void Compute(typename Mesh::Pointer& mesh, const PinMap& pins)
     {
-        std::size_t p0, p1;
-        AutoSelectPins(mesh, p0, p1);
-        ComputeImpl(mesh, p0, p1);
+        validatePins(mesh, pins);
+        ComputeImpl(mesh, pins);
     }
 
     /**
-     * @brief Compute with explicit pinned vertex indices
+     * @brief Deprecated: compute with an explicit pin pair by index.
      *
-     * @throws SolverException if any hierarchy level fails to solve
+     * Builds a 2-entry PinMap using the LSCM axis-snap convention and
+     * dispatches to the PinMap path.
+     *
+     * @deprecated Prefer `Compute(mesh, PinMap)`. This overload will be
+     * removed in version 3.0.
      */
-    static void Compute(typename Mesh::Pointer& mesh, std::size_t pin0Idx, std::size_t pin1Idx)
+    [[deprecated("Use Compute(mesh, PinMap); will be removed in 3.0")]] static void Compute(
+        typename Mesh::Pointer& mesh, std::size_t pin0Idx, std::size_t pin1Idx)
     {
-        ComputeImpl(mesh, pin0Idx, pin1Idx);
+        ComputeImpl(mesh, autoPlacePair(mesh, pin0Idx, pin1Idx));
     }
 
 private:
-    /** Select two pinned boundary vertices (same logic as AngleBasedLSCM) */
-    static void AutoSelectPins(const typename Mesh::Pointer& mesh, std::size_t& p0, std::size_t& p1)
+    /** Walk the boundary to pick the default pin pair as (idx, idx). */
+    static auto selectBoundaryPair(const typename Mesh::Pointer& mesh)
+        -> std::pair<std::size_t, std::size_t>
     {
         auto boundary = mesh->vertices_boundary();
         if (boundary.empty()) {
@@ -4497,8 +4675,54 @@ private:
         if (e == v0->edge && !e->pair->is_boundary()) {
             throw MeshException("Pinned vertex not on boundary");
         }
-        p0 = v0->idx;
-        p1 = e->next->vertex->idx;
+        return {v0->idx, e->next->vertex->idx};
+    }
+
+    /**
+     * @brief Build a 2-entry PinMap from explicit indices using the LSCM
+     * axis-snap convention (pin0 at the UV origin, pin1 on the dominant
+     * world-axis of `(p1 - p0)`).
+     */
+    static auto autoPlacePair(const typename Mesh::Pointer& mesh, std::size_t p0Idx,
+                              std::size_t p1Idx) -> PinMap
+    {
+        auto p0 = mesh->vertex(p0Idx);
+        auto p1 = mesh->vertex(p1Idx);
+        auto pinVec = p1->pos - p0->pos;
+        auto dist = norm(pinVec);
+        pinVec /= dist;
+        auto maxElem = std::max_element(pinVec.begin(), pinVec.end());
+        auto maxAxis = std::distance(pinVec.begin(), maxElem);
+        dist = std::copysign(dist, *maxElem);
+        Vec<T, 2> uv0{T(0), T(0)};
+        Vec<T, 2> uv1 = (maxAxis == 0) ? Vec<T, 2>{dist, T(0)} : Vec<T, 2>{T(0), dist};
+        return PinMap{{p0Idx, uv0}, {p1Idx, uv1}};
+    }
+
+    /** Auto-select two boundary pins and place them via axis-snap. */
+    static auto autoSelectPins(const typename Mesh::Pointer& mesh) -> PinMap
+    {
+        auto [p0Idx, p1Idx] = selectBoundaryPair(mesh);
+        return autoPlacePair(mesh, p0Idx, p1Idx);
+    }
+
+    /** Validate the user-supplied PinMap against `mesh`. */
+    static void validatePins(const typename Mesh::Pointer& mesh, const PinMap& pins)
+    {
+        if (pins.size() < 2) {
+            throw std::invalid_argument("HierarchicalLSCM: PinMap requires at least 2 pins");
+        }
+        auto numVerts = mesh->num_vertices();
+        std::unordered_set<std::size_t> seen;
+        seen.reserve(pins.size());
+        for (const auto& [vIdx, uv] : pins) {
+            if (vIdx >= numVerts) {
+                throw std::invalid_argument("HierarchicalLSCM: PinMap vertex index out of range");
+            }
+            if (!seen.insert(vIdx).second) {
+                throw std::invalid_argument("HierarchicalLSCM: PinMap has duplicate vertex index");
+            }
+        }
     }
 
     /**
@@ -4525,22 +4749,31 @@ private:
     }
 
     /**
-     * @brief Core hierarchical LSCM solve given resolved pin indices
+     * @brief Core hierarchical LSCM solve given a resolved PinMap
      *
-     * Builds the mesh hierarchy, solves LSCM at the coarsest level, then
-     * prolongates and refines at each finer level.
+     * Builds the mesh hierarchy with each pinned vertex flagged as
+     * non-collapsible, solves LSCM at the coarsest level, then prolongates and
+     * refines at each finer level. Pin UVs come from the PinMap verbatim;
+     * non-pin vertex UVs are written by the solve.
      */
-    static void ComputeImpl(typename Mesh::Pointer& mesh, std::size_t pin0Idx, std::size_t pin1Idx,
+    static void ComputeImpl(typename Mesh::Pointer& mesh, const PinMap& pins,
                             std::size_t levelRatio = 10, std::size_t minCoarseVerts = 100)
     {
+        // Extract just the indices for the hierarchy's non-collapsible set.
+        std::vector<std::size_t> pinIndices;
+        pinIndices.reserve(pins.size());
+        for (const auto& [vIdx, uv] : pins) {
+            pinIndices.push_back(vIdx);
+        }
+
         // Build mesh hierarchy
         auto [levels, collapsesByLevel] =
-            detail::hlscm::buildHierarchy<T>(mesh, pin0Idx, pin1Idx, levelRatio, minCoarseVerts);
+            detail::hlscm::buildHierarchy<T>(mesh, pinIndices, levelRatio, minCoarseVerts);
 
         if (levels.size() <= 1) {
-            // Mesh too small for hierarchy — single-level LSCM solve
-            // Use AngleBasedLSCM for exact equivalence on small meshes
-            AngleBasedLSCM<T, MeshType, Solver>::Compute(mesh, pin0Idx, pin1Idx);
+            // Mesh too small for hierarchy — single-level LSCM solve.
+            // Delegate to AngleBasedLSCM with the same pins.
+            AngleBasedLSCM<T, MeshType, Solver>::Compute(mesh, pins);
             return;
         }
 
@@ -4552,8 +4785,8 @@ private:
         auto coarsestIdx = levels.size() - 1;
         auto coarseMesh = detail::hlscm::buildLevelMesh<T>(levels[coarsestIdx]);
         ComputeMeshAngles(coarseMesh);
-        auto uvs = detail::hlscm::solveLSCMLevel<T, Solver>(
-            coarseMesh, levels[coarsestIdx], pin0Idx, pin1Idx, origVertCount, nullptr);
+        auto uvs = detail::hlscm::solveLSCMLevel<T, Solver>(coarseMesh, levels[coarsestIdx], pins,
+                                                            origVertCount, nullptr);
 
         // Prolongate and refine at each finer level
         for (std::size_t k = coarsestIdx; k-- > 0;) {
@@ -4572,7 +4805,7 @@ private:
             }
 
             // Solve with initial guess
-            uvs = detail::hlscm::solveLSCMLevel<T, Solver>(levelMesh, levels[k], pin0Idx, pin1Idx,
+            uvs = detail::hlscm::solveLSCMLevel<T, Solver>(levelMesh, levels[k], pins,
                                                            origVertCount, &uvs);
         }
 
@@ -4586,8 +4819,10 @@ private:
         }
     }
 
-    /** Optional explicit pin pair */
-    std::optional<std::pair<std::size_t, std::size_t>> pinnedVertices_;
+    /** Optional explicit pin set configured via `setPins()`. */
+    std::optional<PinMap> pins_;
+    /** Deprecated: legacy two-pin index pair set via `setPinnedVertices`. */
+    std::optional<std::pair<std::size_t, std::size_t>> legacyPinIndices_;
     /** Ratio of vertices between consecutive hierarchy levels */
     std::size_t levelRatio_{10};
     /** Minimum vertex count for the coarsest hierarchy level */

--- a/single_include/OpenABF/OpenABF.hpp
+++ b/single_include/OpenABF/OpenABF.hpp
@@ -3066,11 +3066,16 @@ private:
 #include <array>
 #include <cmath>
 #include <cstddef>
+#include <iterator>
+#include <stdexcept>
 #include <unordered_map>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
 #include <Eigen/SparseCore>
+
+// #include "OpenABF/Math.hpp"
 
 // #include "OpenABF/Vec.hpp"
 
@@ -3085,6 +3090,69 @@ namespace OpenABF::detail::lscm
  */
 template <typename T>
 using PinMap = std::vector<std::pair<std::size_t, OpenABF::Vec<T, 2>>>;
+
+/**
+ * @brief Validate a user-supplied PinMap against `mesh`.
+ *
+ * Throws `std::invalid_argument` if the PinMap has fewer than two pins, a
+ * duplicate vertex index, or an out-of-range vertex index. Shared by
+ * `AngleBasedLSCM` and `HierarchicalLSCM` so behavior matches at the public
+ * boundary.
+ */
+template <typename T, class MeshType>
+void validatePins(const typename MeshType::Pointer& mesh, const PinMap<T>& pins)
+{
+    if (pins.size() < 2) {
+        throw std::invalid_argument("LSCM: PinMap requires at least 2 pins");
+    }
+    const auto numVerts = mesh->num_vertices();
+    std::unordered_set<std::size_t> seen;
+    seen.reserve(pins.size());
+    for (const auto& [vIdx, uv] : pins) {
+        if (vIdx >= numVerts) {
+            throw std::invalid_argument("LSCM: PinMap vertex index out of range");
+        }
+        if (!seen.insert(vIdx).second) {
+            throw std::invalid_argument("LSCM: PinMap has duplicate vertex index");
+        }
+    }
+}
+
+/**
+ * @brief Build a 2-entry PinMap from explicit vertex indices using the LSCM
+ * axis-snap convention.
+ *
+ * pin0 lands at `{0, 0}`; pin1 lands at signed distance `|p1 - p0|` on
+ * whichever world-axis the `(p1 - p0)` vector has the largest magnitude.
+ * Used by the auto-pin path and by the deprecated 2-pin shims.
+ *
+ * Throws `std::invalid_argument` if `p0Idx == p1Idx` (the resulting
+ * zero-length axis-snap would divide by zero and produce NaN UVs) or if
+ * either index is out of range.
+ */
+template <typename T, class MeshType>
+auto autoPlacePair(const typename MeshType::Pointer& mesh, std::size_t p0Idx, std::size_t p1Idx)
+    -> PinMap<T>
+{
+    const auto numVerts = mesh->num_vertices();
+    if (p0Idx >= numVerts || p1Idx >= numVerts) {
+        throw std::invalid_argument("LSCM: pin vertex index out of range");
+    }
+    if (p0Idx == p1Idx) {
+        throw std::invalid_argument("LSCM: pin pair must be two distinct vertices");
+    }
+    auto p0 = mesh->vertex(p0Idx);
+    auto p1 = mesh->vertex(p1Idx);
+    auto pinVec = p1->pos - p0->pos;
+    auto dist = norm(pinVec);
+    pinVec /= dist;
+    auto maxElem = std::max_element(pinVec.begin(), pinVec.end());
+    auto maxAxis = std::distance(pinVec.begin(), maxElem);
+    dist = std::copysign(dist, *maxElem);
+    Vec<T, 2> uv0{T(0), T(0)};
+    Vec<T, 2> uv1 = (maxAxis == 0) ? Vec<T, 2>{dist, T(0)} : Vec<T, 2>{T(0), dist};
+    return PinMap<T>{{p0Idx, uv0}, {p1Idx, uv1}};
+}
 
 /**
  * @brief Outputs of `buildSystem`: the LSCM least-squares system for a mesh
@@ -3108,11 +3176,16 @@ struct SystemParts {
 /**
  * @brief Build the LSCM sparse system for a mesh with N pinned vertices.
  *
- * Mutates the mesh: each pinned vertex's `pos` is overwritten with `{uv[0],
- * uv[1], 0}` (the caller's chosen UV). The function does NOT auto-place pins
- * — UVs are taken verbatim from the PinMap. Callers that want the LSCM
- * axis-snap convention (origin + dominant-axis placement for an auto-selected
- * pair) compute those UVs themselves before calling this helper.
+ * Pure with respect to the mesh — only reads `alpha` and connectivity. Pin
+ * UVs are taken verbatim from the PinMap into `bFixed`; the mesh's vertex
+ * positions are NOT mutated. Callers that need pin UVs reflected on the mesh
+ * (e.g., `AngleBasedLSCM::ComputeImpl`'s output writeback) must do that
+ * themselves.
+ *
+ * The function does NOT auto-place pins — UVs are taken verbatim from the
+ * PinMap. Callers that want the LSCM axis-snap convention (origin +
+ * dominant-axis placement for an auto-selected pair) compute those UVs
+ * themselves via `autoPlacePair` before calling this helper.
  *
  * Assembly follows Lévy et al. 2002 Eq. 10 using the per-edge `alpha` angles
  * already stored on the mesh.
@@ -3135,13 +3208,11 @@ auto buildSystem(const typename MeshType::Pointer& mesh, const PinMap<T>& pins) 
         pinSlot.emplace(pins[s].first, s);
     }
 
-    // Write pin UVs into the mesh and into bFixed.
+    // Populate bFixed from PinMap UVs (verbatim).
     std::vector<Triplet> tripletsB;
     tripletsB.reserve(2 * numFixed);
     for (std::size_t s = 0; s < numFixed; ++s) {
-        const auto& [vIdx, uv] = pins[s];
-        auto v = mesh->vertex(vIdx);
-        v->pos = {uv[0], uv[1], T(0)};
+        const auto& uv = pins[s].second;
         tripletsB.emplace_back(2 * s, 0, uv[0]);
         tripletsB.emplace_back(2 * s + 1, 0, uv[1]);
     }
@@ -3392,8 +3463,8 @@ public:
         if (pins_) {
             Compute(mesh, *pins_);
         } else if (legacyPinIndices_) {
-            ComputeImpl(mesh,
-                        autoPlacePair(mesh, legacyPinIndices_->first, legacyPinIndices_->second));
+            ComputeImpl(mesh, detail::lscm::autoPlacePair<T, Mesh>(mesh, legacyPinIndices_->first,
+                                                                   legacyPinIndices_->second));
         } else {
             Compute(mesh);
         }
@@ -3427,7 +3498,7 @@ public:
      */
     static void Compute(typename Mesh::Pointer& mesh, const PinMap& pins)
     {
-        validatePins(mesh, pins);
+        detail::lscm::validatePins<T, Mesh>(mesh, pins);
         ComputeImpl(mesh, pins);
     }
 
@@ -3444,7 +3515,7 @@ public:
     [[deprecated("Use Compute(mesh, PinMap); will be removed in 3.0")]] static void Compute(
         typename Mesh::Pointer& mesh, std::size_t pin0Idx, std::size_t pin1Idx)
     {
-        ComputeImpl(mesh, autoPlacePair(mesh, pin0Idx, pin1Idx));
+        ComputeImpl(mesh, detail::lscm::autoPlacePair<T, Mesh>(mesh, pin0Idx, pin1Idx));
     }
 
 private:
@@ -3476,56 +3547,11 @@ private:
         return {p0, p1};
     }
 
-    /**
-     * @brief Build a 2-entry PinMap from explicit indices using the LSCM
-     * axis-snap convention.
-     *
-     * pin0 at `{0, 0}`, pin1 at signed distance `|p1 - p0|` on whichever world
-     * axis the `(p1 - p0)` vector has the largest magnitude.
-     */
-    static auto autoPlacePair(const typename Mesh::Pointer& mesh, std::size_t p0Idx,
-                              std::size_t p1Idx) -> PinMap
-    {
-        auto p0 = mesh->vertex(p0Idx);
-        auto p1 = mesh->vertex(p1Idx);
-        auto pinVec = p1->pos - p0->pos;
-        auto dist = norm(pinVec);
-        pinVec /= dist;
-        auto maxElem = std::max_element(pinVec.begin(), pinVec.end());
-        auto maxAxis = std::distance(pinVec.begin(), maxElem);
-        dist = std::copysign(dist, *maxElem);
-        Vec<T, 2> uv0{T(0), T(0)};
-        Vec<T, 2> uv1 = (maxAxis == 0) ? Vec<T, 2>{dist, T(0)} : Vec<T, 2>{T(0), dist};
-        return PinMap{{p0Idx, uv0}, {p1Idx, uv1}};
-    }
-
-    /**
-     * @brief Auto-select two boundary pins and place them via the LSCM
-     * axis-snap convention.
-     */
+    /** Auto-select two boundary pins and place them via the LSCM axis-snap convention. */
     static auto autoSelectPins(const typename Mesh::Pointer& mesh) -> PinMap
     {
         auto [p0, p1] = selectBoundaryPair(mesh);
-        return autoPlacePair(mesh, p0->idx, p1->idx);
-    }
-
-    /** Validate that the user's PinMap is well-formed for this mesh. */
-    static void validatePins(const typename Mesh::Pointer& mesh, const PinMap& pins)
-    {
-        if (pins.size() < 2) {
-            throw std::invalid_argument("AngleBasedLSCM: PinMap requires at least 2 pins");
-        }
-        auto numVerts = mesh->num_vertices();
-        std::unordered_set<std::size_t> seen;
-        seen.reserve(pins.size());
-        for (const auto& [vIdx, uv] : pins) {
-            if (vIdx >= numVerts) {
-                throw std::invalid_argument("AngleBasedLSCM: PinMap vertex index out of range");
-            }
-            if (!seen.insert(vIdx).second) {
-                throw std::invalid_argument("AngleBasedLSCM: PinMap has duplicate vertex index");
-            }
-        }
+        return detail::lscm::autoPlacePair<T, Mesh>(mesh, p0->idx, p1->idx);
     }
 
     /**
@@ -3537,19 +3563,22 @@ private:
         using SparseMatrix = Eigen::SparseMatrix<T>;
         using DenseMatrix = Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>;
 
-        // Pin placement + LSCM system assembly (shared with HierarchicalLSCM)
+        // LSCM system assembly (shared with HierarchicalLSCM). buildSystem
+        // does not mutate the mesh; pin UVs are written below.
         auto parts = detail::lscm::buildSystem<T, Mesh>(mesh, pins);
 
         // Solve for x
         auto x = detail::SolveLeastSquares<SparseMatrix, DenseMatrix, Solver>(parts.A, parts.b);
 
-        // Assign solution to free vertices. Pin vertices are already at their
-        // target UVs (written by buildSystem).
+        // Write pin UVs onto the mesh from the PinMap.
         std::unordered_set<std::size_t> pinIdx;
         pinIdx.reserve(pins.size());
         for (const auto& [vIdx, uv] : pins) {
+            auto v = mesh->vertex(vIdx);
+            v->pos = {uv[0], uv[1], T(0)};
             pinIdx.insert(vIdx);
         }
+        // Write solved UVs onto each free vertex.
         for (const auto& v : mesh->vertices()) {
             if (pinIdx.count(v->idx)) {
                 continue;
@@ -4379,13 +4408,21 @@ auto solveLSCMLevel(const typename HalfEdgeMesh<T>::Pointer& levelMesh,
     auto numFree = numVerts - numFixed;
 
     // Map each original pin idx to its level-local idx. Pins are guaranteed
-    // to survive every decimation level so the unwrap is safe.
+    // to survive every decimation level (DecimationMesh::tryCollapse rejects
+    // collapses of pinned vertices), so this unwrap is expected to succeed.
+    // Throw a meaningful exception rather than std::bad_optional_access if a
+    // future refactor ever breaks the invariant.
     detail::lscm::PinMap<T> localPins;
     localPins.reserve(numFixed);
     std::unordered_set<std::size_t> localPinIdx;
     localPinIdx.reserve(numFixed);
     for (const auto& [origIdx, uv] : origPins) {
-        auto localIdx = *level.originalToLocal[origIdx];
+        const auto& localOpt = level.originalToLocal[origIdx];
+        if (!localOpt.has_value()) {
+            throw SolverException(
+                "HLSCM: pinned vertex was removed during decimation (invariant violated)");
+        }
+        auto localIdx = *localOpt;
         localPins.emplace_back(localIdx, uv);
         localPinIdx.insert(localIdx);
     }
@@ -4607,8 +4644,10 @@ public:
         PinMap pins;
         if (pins_) {
             pins = *pins_;
+            detail::lscm::validatePins<T, Mesh>(mesh, pins);
         } else if (legacyPinIndices_) {
-            pins = autoPlacePair(mesh, legacyPinIndices_->first, legacyPinIndices_->second);
+            pins = detail::lscm::autoPlacePair<T, Mesh>(mesh, legacyPinIndices_->first,
+                                                        legacyPinIndices_->second);
         } else {
             pins = autoSelectPins(mesh);
         }
@@ -4636,7 +4675,7 @@ public:
      */
     static void Compute(typename Mesh::Pointer& mesh, const PinMap& pins)
     {
-        validatePins(mesh, pins);
+        detail::lscm::validatePins<T, Mesh>(mesh, pins);
         ComputeImpl(mesh, pins);
     }
 
@@ -4652,7 +4691,7 @@ public:
     [[deprecated("Use Compute(mesh, PinMap); will be removed in 3.0")]] static void Compute(
         typename Mesh::Pointer& mesh, std::size_t pin0Idx, std::size_t pin1Idx)
     {
-        ComputeImpl(mesh, autoPlacePair(mesh, pin0Idx, pin1Idx));
+        ComputeImpl(mesh, detail::lscm::autoPlacePair<T, Mesh>(mesh, pin0Idx, pin1Idx));
     }
 
 private:
@@ -4678,51 +4717,11 @@ private:
         return {v0->idx, e->next->vertex->idx};
     }
 
-    /**
-     * @brief Build a 2-entry PinMap from explicit indices using the LSCM
-     * axis-snap convention (pin0 at the UV origin, pin1 on the dominant
-     * world-axis of `(p1 - p0)`).
-     */
-    static auto autoPlacePair(const typename Mesh::Pointer& mesh, std::size_t p0Idx,
-                              std::size_t p1Idx) -> PinMap
-    {
-        auto p0 = mesh->vertex(p0Idx);
-        auto p1 = mesh->vertex(p1Idx);
-        auto pinVec = p1->pos - p0->pos;
-        auto dist = norm(pinVec);
-        pinVec /= dist;
-        auto maxElem = std::max_element(pinVec.begin(), pinVec.end());
-        auto maxAxis = std::distance(pinVec.begin(), maxElem);
-        dist = std::copysign(dist, *maxElem);
-        Vec<T, 2> uv0{T(0), T(0)};
-        Vec<T, 2> uv1 = (maxAxis == 0) ? Vec<T, 2>{dist, T(0)} : Vec<T, 2>{T(0), dist};
-        return PinMap{{p0Idx, uv0}, {p1Idx, uv1}};
-    }
-
     /** Auto-select two boundary pins and place them via axis-snap. */
     static auto autoSelectPins(const typename Mesh::Pointer& mesh) -> PinMap
     {
         auto [p0Idx, p1Idx] = selectBoundaryPair(mesh);
-        return autoPlacePair(mesh, p0Idx, p1Idx);
-    }
-
-    /** Validate the user-supplied PinMap against `mesh`. */
-    static void validatePins(const typename Mesh::Pointer& mesh, const PinMap& pins)
-    {
-        if (pins.size() < 2) {
-            throw std::invalid_argument("HierarchicalLSCM: PinMap requires at least 2 pins");
-        }
-        auto numVerts = mesh->num_vertices();
-        std::unordered_set<std::size_t> seen;
-        seen.reserve(pins.size());
-        for (const auto& [vIdx, uv] : pins) {
-            if (vIdx >= numVerts) {
-                throw std::invalid_argument("HierarchicalLSCM: PinMap vertex index out of range");
-            }
-            if (!seen.insert(vIdx).second) {
-                throw std::invalid_argument("HierarchicalLSCM: PinMap has duplicate vertex index");
-            }
-        }
+        return detail::lscm::autoPlacePair<T, Mesh>(mesh, p0Idx, p1Idx);
     }
 
     /**

--- a/tests/src/TestParameterization.cpp
+++ b/tests/src/TestParameterization.cpp
@@ -1463,6 +1463,180 @@ TEST(HLSCM, MultiPin_Hemisphere)
     }
 }
 
+TEST(Parameterization, AngleBasedLSCM_PinMap_Rejects_TooFew)
+{
+    using LSCM = AngleBasedLSCM<float>;
+    using PinMap = typename LSCM::PinMap;
+
+    auto mesh = ConstructPyramid<LSCM::Mesh>();
+    PinMap pins{{0u, Vec<float, 2>{0.f, 0.f}}};  // only 1 pin
+    EXPECT_THROW(LSCM::Compute(mesh, pins), std::invalid_argument);
+}
+
+TEST(Parameterization, AngleBasedLSCM_PinMap_Rejects_Duplicate)
+{
+    using LSCM = AngleBasedLSCM<float>;
+    using PinMap = typename LSCM::PinMap;
+
+    auto mesh = ConstructPyramid<LSCM::Mesh>();
+    PinMap pins{
+        {0u, Vec<float, 2>{0.f, 0.f}},
+        {0u, Vec<float, 2>{2.f, 0.f}},  // same index repeated
+    };
+    EXPECT_THROW(LSCM::Compute(mesh, pins), std::invalid_argument);
+}
+
+TEST(Parameterization, AngleBasedLSCM_PinMap_Rejects_OutOfRange)
+{
+    using LSCM = AngleBasedLSCM<float>;
+    using PinMap = typename LSCM::PinMap;
+
+    auto mesh = ConstructPyramid<LSCM::Mesh>();  // 4 vertices
+    PinMap pins{
+        {0u, Vec<float, 2>{0.f, 0.f}},
+        {99u, Vec<float, 2>{2.f, 0.f}},  // out of range
+    };
+    EXPECT_THROW(LSCM::Compute(mesh, pins), std::invalid_argument);
+}
+
+TEST(Parameterization, AngleBasedLSCM_MultiPin_FourPins_Grid)
+{
+    // Pin all four corners of a 4x4 grid to a unit square in UV space.
+    using LSCM = AngleBasedLSCM<float>;
+    using PinMap = typename LSCM::PinMap;
+
+    auto mesh = ConstructGrid<LSCM::Mesh>(4, 4);  // 16 vertices, corner indices 0,3,12,15
+    PinMap pins{
+        {0u, Vec<float, 2>{0.f, 0.f}},
+        {3u, Vec<float, 2>{1.f, 0.f}},
+        {12u, Vec<float, 2>{0.f, 1.f}},
+        {15u, Vec<float, 2>{1.f, 1.f}},
+    };
+    LSCM::Compute(mesh, pins);
+
+    for (const auto& [vIdx, uv] : pins) {
+        const auto& p = mesh->vertex(vIdx)->pos;
+        EXPECT_FLOAT_EQ(p[0], uv[0]) << "pin v" << vIdx << " u";
+        EXPECT_FLOAT_EQ(p[1], uv[1]) << "pin v" << vIdx << " v";
+        EXPECT_FLOAT_EQ(p[2], 0.f) << "pin v" << vIdx << " z";
+    }
+}
+
+TEST(Parameterization, AngleBasedLSCM_SetPins_OverridesSetPinnedVertices)
+{
+    // setPins() called after the deprecated setPinnedVertices() must win.
+    using LSCM = AngleBasedLSCM<float>;
+    using PinMap = typename LSCM::PinMap;
+
+    auto mesh = ConstructPyramid<LSCM::Mesh>();
+    PinMap pins{
+        {0u, Vec<float, 2>{0.f, 0.f}},
+        {1u, Vec<float, 2>{2.f, 0.f}},
+        {2u, Vec<float, 2>{1.f, std::sqrt(3.f)}},
+    };
+
+    LSCM lscm;
+    // Configure the deprecated path first; setPins() must clear it.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+    lscm.setPinnedVertices(0, 1);
+#pragma clang diagnostic pop
+#pragma GCC diagnostic pop
+    lscm.setPins(pins);
+    lscm.compute(mesh);
+
+    // All three pins must land exactly — the 2-pin legacy path would not
+    // have produced these UVs for vertex 2.
+    for (const auto& [vIdx, uv] : pins) {
+        const auto& p = mesh->vertex(vIdx)->pos;
+        EXPECT_FLOAT_EQ(p[0], uv[0]) << "pin v" << vIdx << " u";
+        EXPECT_FLOAT_EQ(p[1], uv[1]) << "pin v" << vIdx << " v";
+    }
+}
+
+TEST(HLSCM, PinMap_Rejects_TooFew)
+{
+    using HLSCM = HierarchicalLSCM<float>;
+    using PinMap = typename HLSCM::PinMap;
+
+    auto mesh = ConstructPyramid<HLSCM::Mesh>();
+    PinMap pins{{0u, Vec<float, 2>{0.f, 0.f}}};
+    EXPECT_THROW(HLSCM::Compute(mesh, pins), std::invalid_argument);
+}
+
+TEST(HLSCM, PinMap_Rejects_Duplicate)
+{
+    using HLSCM = HierarchicalLSCM<float>;
+    using PinMap = typename HLSCM::PinMap;
+
+    auto mesh = ConstructPyramid<HLSCM::Mesh>();
+    PinMap pins{
+        {0u, Vec<float, 2>{0.f, 0.f}},
+        {0u, Vec<float, 2>{2.f, 0.f}},
+    };
+    EXPECT_THROW(HLSCM::Compute(mesh, pins), std::invalid_argument);
+}
+
+TEST(HLSCM, PinMap_Rejects_OutOfRange)
+{
+    using HLSCM = HierarchicalLSCM<float>;
+    using PinMap = typename HLSCM::PinMap;
+
+    auto mesh = ConstructPyramid<HLSCM::Mesh>();
+    PinMap pins{
+        {0u, Vec<float, 2>{0.f, 0.f}},
+        {99u, Vec<float, 2>{2.f, 0.f}},
+    };
+    EXPECT_THROW(HLSCM::Compute(mesh, pins), std::invalid_argument);
+}
+
+TEST(HLSCM, Instance_PinMap_Rejects_OutOfRange)
+{
+    // Regression guard: HLSCM instance compute() must validate the PinMap
+    // before forwarding to ComputeImpl/buildHierarchy (which would otherwise
+    // out-of-bounds-write into DecimationMesh::isPinned_).
+    using HLSCM = HierarchicalLSCM<float>;
+    using PinMap = typename HLSCM::PinMap;
+
+    auto mesh = ConstructPyramid<HLSCM::Mesh>();
+    PinMap pins{
+        {0u, Vec<float, 2>{0.f, 0.f}},
+        {99u, Vec<float, 2>{2.f, 0.f}},
+    };
+    HLSCM hlscm;
+    hlscm.setPins(pins);
+    EXPECT_THROW(hlscm.compute(mesh), std::invalid_argument);
+}
+
+TEST(HLSCM, MultiPin_FourPins_Grid)
+{
+    // Pin all four corners of an 8x8 grid; verify exact UV landing on every
+    // pin even after the hierarchy build/prolongate/refine path runs.
+    using HLSCM = HierarchicalLSCM<float>;
+    using PinMap = typename HLSCM::PinMap;
+
+    auto mesh = ConstructGrid<HLSCM::Mesh>(8, 8);  // 64 verts, corners 0,7,56,63
+    PinMap pins{
+        {0u, Vec<float, 2>{0.f, 0.f}},
+        {7u, Vec<float, 2>{1.f, 0.f}},
+        {56u, Vec<float, 2>{0.f, 1.f}},
+        {63u, Vec<float, 2>{1.f, 1.f}},
+    };
+    HLSCM hlscm;
+    hlscm.setMinCoarseVertices(10);  // force at least one decimation level
+    hlscm.setPins(pins);
+    hlscm.compute(mesh);
+
+    for (const auto& [vIdx, uv] : pins) {
+        const auto& p = mesh->vertex(vIdx)->pos;
+        EXPECT_FLOAT_EQ(p[0], uv[0]) << "pin v" << vIdx << " u";
+        EXPECT_FLOAT_EQ(p[1], uv[1]) << "pin v" << vIdx << " v";
+        EXPECT_FLOAT_EQ(p[2], 0.f) << "pin v" << vIdx << " z";
+    }
+}
+
 TEST(HLSCM, SetPins_MatchesStatic)
 {
     // Instance setPins() must produce identical output to the static

--- a/tests/src/TestParameterization.cpp
+++ b/tests/src/TestParameterization.cpp
@@ -1372,7 +1372,7 @@ TEST(Parameterization, AngleBasedLSCM_MultiPin_Pyramid)
 
 TEST(Parameterization, AngleBasedLSCM_SetPins_MatchesStatic)
 {
-    // The instance setPins() form must produce identical output to the static
+    // The instance set_pins() form must produce identical output to the static
     // Compute(mesh, PinMap) overload for the same pins.
     using LSCM = AngleBasedLSCM<float>;
     using PinMap = typename LSCM::PinMap;
@@ -1388,7 +1388,7 @@ TEST(Parameterization, AngleBasedLSCM_SetPins_MatchesStatic)
 
     auto mesh_instance = ConstructPyramid<LSCM::Mesh>();
     LSCM lscm;
-    lscm.setPins(pins);
+    lscm.set_pins(pins);
     lscm.compute(mesh_instance);
 
     for (std::size_t v = 0; v < mesh_static->num_vertices(); ++v) {
@@ -1480,7 +1480,8 @@ TEST(Parameterization, AngleBasedLSCM_PinMap_Rejects_Duplicate)
 
     auto mesh = ConstructPyramid<LSCM::Mesh>();
     PinMap pins{
-        {0u, Vec<float, 2>{0.f, 0.f}}, {0u, Vec<float, 2>{2.f, 0.f}},  // same index repeated
+        {0u, Vec<float, 2>{0.f, 0.f}},
+        {0u, Vec<float, 2>{2.f, 0.f}},  // same index repeated
     };
     EXPECT_THROW(LSCM::Compute(mesh, pins), std::invalid_argument);
 }
@@ -1492,7 +1493,8 @@ TEST(Parameterization, AngleBasedLSCM_PinMap_Rejects_OutOfRange)
 
     auto mesh = ConstructPyramid<LSCM::Mesh>();  // 4 vertices
     PinMap pins{
-        {0u, Vec<float, 2>{0.f, 0.f}}, {99u, Vec<float, 2>{2.f, 0.f}},  // out of range
+        {0u, Vec<float, 2>{0.f, 0.f}},
+        {99u, Vec<float, 2>{2.f, 0.f}},  // out of range
     };
     EXPECT_THROW(LSCM::Compute(mesh, pins), std::invalid_argument);
 }
@@ -1522,7 +1524,7 @@ TEST(Parameterization, AngleBasedLSCM_MultiPin_FourPins_Grid)
 
 TEST(Parameterization, AngleBasedLSCM_SetPins_OverridesSetPinnedVertices)
 {
-    // setPins() called after the deprecated setPinnedVertices() must win.
+    // set_pins() called after the deprecated setPinnedVertices() must win.
     using LSCM = AngleBasedLSCM<float>;
     using PinMap = typename LSCM::PinMap;
 
@@ -1534,7 +1536,7 @@ TEST(Parameterization, AngleBasedLSCM_SetPins_OverridesSetPinnedVertices)
     };
 
     LSCM lscm;
-    // Configure the deprecated path first; setPins() must clear it.
+    // Configure the deprecated path first; set_pins() must clear it.
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #pragma clang diagnostic push
@@ -1542,7 +1544,7 @@ TEST(Parameterization, AngleBasedLSCM_SetPins_OverridesSetPinnedVertices)
     lscm.setPinnedVertices(0, 1);
 #pragma clang diagnostic pop
 #pragma GCC diagnostic pop
-    lscm.setPins(pins);
+    lscm.set_pins(pins);
     lscm.compute(mesh);
 
     // All three pins must land exactly — the 2-pin legacy path would not
@@ -1604,7 +1606,7 @@ TEST(HLSCM, Instance_PinMap_Rejects_OutOfRange)
         {99u, Vec<float, 2>{2.f, 0.f}},
     };
     HLSCM hlscm;
-    hlscm.setPins(pins);
+    hlscm.set_pins(pins);
     EXPECT_THROW(hlscm.compute(mesh), std::invalid_argument);
 }
 
@@ -1624,7 +1626,7 @@ TEST(HLSCM, MultiPin_FourPins_Grid)
     };
     HLSCM hlscm;
     hlscm.setMinCoarseVertices(10);  // force at least one decimation level
-    hlscm.setPins(pins);
+    hlscm.set_pins(pins);
     hlscm.compute(mesh);
 
     for (const auto& [vIdx, uv] : pins) {
@@ -1637,7 +1639,7 @@ TEST(HLSCM, MultiPin_FourPins_Grid)
 
 TEST(HLSCM, SetPins_MatchesStatic)
 {
-    // Instance setPins() must produce identical output to the static
+    // Instance set_pins() must produce identical output to the static
     // Compute(mesh, PinMap) overload.
     using HLSCM = HierarchicalLSCM<float>;
     using PinMap = typename HLSCM::PinMap;
@@ -1653,7 +1655,7 @@ TEST(HLSCM, SetPins_MatchesStatic)
 
     auto mesh_instance = ConstructPyramid<HLSCM::Mesh>();
     HLSCM hlscm;
-    hlscm.setPins(pins);
+    hlscm.set_pins(pins);
     hlscm.compute(mesh_instance);
 
     for (std::size_t v = 0; v < mesh_static->num_vertices(); ++v) {

--- a/tests/src/TestParameterization.cpp
+++ b/tests/src/TestParameterization.cpp
@@ -517,10 +517,11 @@ TEST(HLSCM, InstanceAPILevelRatio)
     constexpr std::size_t pin1 = 19;  // opposite corner of a 20x20 grid row
     constexpr std::size_t minCoarseVerts = 10;
 
+    const std::vector<std::size_t> pinIndices{pin0, pin1};
     auto [levelsSmall, _csmall] =
-        buildHierarchy<float>(mesh2, pin0, pin1, /*levelRatio=*/2, minCoarseVerts);
+        buildHierarchy<float>(mesh2, pinIndices, /*levelRatio=*/2, minCoarseVerts);
     auto [levelsLarge, _clarge] =
-        buildHierarchy<float>(mesh2, pin0, pin1, /*levelRatio=*/8, minCoarseVerts);
+        buildHierarchy<float>(mesh2, pinIndices, /*levelRatio=*/8, minCoarseVerts);
 
     // Sanity: both hierarchies have at least the finest level
     ASSERT_GE(levelsSmall.size(), 1u);
@@ -544,9 +545,9 @@ TEST(HLSCM, MultiLevelHierarchy)
     auto mesh = ConstructWavySurface<HLSCM::Mesh>(20, 20);
 
     // Match HLSCM defaults except force a small minCoarseVerts so we get >1 level
-    auto [levels, collapsesByLevel] =
-        OpenABF::detail::hlscm::buildHierarchy<float>(mesh, 0, 1, /*levelRatio=*/10,
-                                                      /*minCoarseVerts=*/10);
+    auto [levels, collapsesByLevel] = OpenABF::detail::hlscm::buildHierarchy<float>(
+        mesh, std::vector<std::size_t>{0, 1}, /*levelRatio=*/10,
+        /*minCoarseVerts=*/10);
     EXPECT_GE(levels.size(), std::size_t(2))
         << "buildHierarchy produced only " << levels.size() << " level(s)";
 
@@ -896,7 +897,7 @@ TEST(HLSCMInternal, DecimationMesh_RejectsPinnedVertex)
     constexpr std::size_t pin0 = 0;
     constexpr std::size_t pin1 = 1;
     DMesh dm;
-    dm.build(mesh, pin0, pin1);
+    dm.build(mesh, std::vector<std::size_t>{pin0, pin1});
 
     // Attempting to remove a pinned vertex (pin0=0 → vertex 1) must return nullopt
     auto result = dm.tryCollapse(pin0, 1);
@@ -923,7 +924,7 @@ TEST(HLSCMInternal, TryCollapse_OutKeepNbrsMatchesVertexNeighbors)
     constexpr std::size_t pin0 = 0;
     constexpr std::size_t pin1 = 7;
     DMesh dm;
-    dm.build(mesh, pin0, pin1);
+    dm.build(mesh, std::vector<std::size_t>{pin0, pin1});
 
     std::vector<std::size_t> outNbrs;
     std::size_t successful = 0;
@@ -966,7 +967,7 @@ TEST(HLSCMInternal, ProlongateUVs_MultiLevelCoverage)
     constexpr std::size_t pin1 = 11;
 
     auto [levels, collapsesByLevel] = OpenABF::detail::hlscm::buildHierarchy<float>(
-        mesh, pin0, pin1, /*levelRatio=*/3, /*minCoarseVerts=*/5);
+        mesh, std::vector<std::size_t>{pin0, pin1}, /*levelRatio=*/3, /*minCoarseVerts=*/5);
     ASSERT_GE(levels.size(), std::size_t(3)) << "Expected at least 3 hierarchy levels";
 
     // Seed coarsest-level UVs with arbitrary deterministic values.
@@ -1008,8 +1009,8 @@ TEST(HLSCMInternal, BuildHierarchy_LevelCount)
     constexpr std::size_t levelRatio = 4;
     constexpr std::size_t minCoarseVerts = 10;
 
-    auto [levels, collapsesByLevel] =
-        OpenABF::detail::hlscm::buildHierarchy<float>(mesh, pin0, pin1, levelRatio, minCoarseVerts);
+    auto [levels, collapsesByLevel] = OpenABF::detail::hlscm::buildHierarchy<float>(
+        mesh, std::vector<std::size_t>{pin0, pin1}, levelRatio, minCoarseVerts);
 
     // 20x20 = 400 verts, ratio 4, min 10  →  400, 100, 25, 10  → 4 levels (≥3)
     ASSERT_GE(levels.size(), std::size_t(3))
@@ -1079,7 +1080,7 @@ TEST(HLSCMInternal, ProlongateUVs_BarycentricReconstruction)
 
     // Force a 2-level hierarchy (25 verts → ~6 verts at ratio 4).
     auto [levels, collapsesByLevel] = OpenABF::detail::hlscm::buildHierarchy<float>(
-        mesh, pin0, pin1, /*levelRatio=*/4, /*minCoarseVerts=*/5);
+        mesh, std::vector<std::size_t>{pin0, pin1}, /*levelRatio=*/4, /*minCoarseVerts=*/5);
     ASSERT_GE(levels.size(), std::size_t(2)) << "Expected at least 2 hierarchy levels";
     ASSERT_FALSE(collapsesByLevel.empty()) << "Expected at least one collapse record set";
 
@@ -1152,7 +1153,7 @@ TEST(HLSCMInternal, SolveLSCMLevel_KnownMesh)
     // Build a single-level hierarchy (pyramid is too small to decimate).
     auto meshH = ConstructPyramid<HLSCM::Mesh>();
     auto [levels, collapsesByLevel] = OpenABF::detail::hlscm::buildHierarchy<float>(
-        meshH, pin0, pin1, /*levelRatio=*/10, /*minCoarseVerts=*/100);
+        meshH, std::vector<std::size_t>{pin0, pin1}, /*levelRatio=*/10, /*minCoarseVerts=*/100);
     ASSERT_EQ(levels.size(), std::size_t(1)) << "Pyramid should produce a single-level hierarchy";
 
     const auto& level = levels[0];
@@ -1160,7 +1161,12 @@ TEST(HLSCMInternal, SolveLSCMLevel_KnownMesh)
     OpenABF::ComputeMeshAngles(levelMesh);
 
     const auto origVertCount = meshH->num_vertices();
-    auto uvs = OpenABF::detail::hlscm::solveLSCMLevel<float, Solver>(levelMesh, level, pin0, pin1,
+    // Match the LSCM axis-snap convention used by the auto-pin path.
+    OpenABF::detail::lscm::PinMap<float> pins{
+        {pin0, OpenABF::Vec<float, 2>{0.f, 0.f}},
+        {pin1, OpenABF::Vec<float, 2>{2.f, 0.f}},
+    };
+    auto uvs = OpenABF::detail::hlscm::solveLSCMLevel<float, Solver>(levelMesh, level, pins,
                                                                      origVertCount, nullptr);
 
     // Pyramid produces a single-level hierarchy, so every vertex must have a UV.
@@ -1215,7 +1221,13 @@ auto BuildPyramidSystem()
     ComputeMeshAngles(mesh);
     auto p0 = mesh->vertex(pin0Idx);
     auto p1 = mesh->vertex(pin1Idx);
-    auto parts = OpenABF::detail::lscm::buildSystem<float, LSCMSystemMesh>(mesh, p0, p1);
+    // Match the LSCM axis-snap convention used by the auto-pin path: pin0 at
+    // the origin, pin1 on the dominant world-axis of (p1->pos - p0->pos).
+    OpenABF::detail::lscm::PinMap<float> pins{
+        {pin0Idx, Vec<float, 2>{0.f, 0.f}},
+        {pin1Idx, Vec<float, 2>{2.f, 0.f}},
+    };
+    auto parts = OpenABF::detail::lscm::buildSystem<float, LSCMSystemMesh>(mesh, pins);
     return std::make_tuple(mesh, p0, p1, std::move(parts));
 }
 
@@ -1298,9 +1310,11 @@ TEST(LSCMSystemBuild, FreeIdxTable_DeterministicAcrossRuns)
     auto runOnce = [&]() {
         auto mesh = ConstructGrid<LSCMSystemMesh>(4, 4);
         ComputeMeshAngles(mesh);
-        auto p0 = mesh->vertex(pin0Idx);
-        auto p1 = mesh->vertex(pin1Idx);
-        return OpenABF::detail::lscm::buildSystem<float, LSCMSystemMesh>(mesh, p0, p1);
+        OpenABF::detail::lscm::PinMap<float> pins{
+            {pin0Idx, Vec<float, 2>{0.f, 0.f}},
+            {pin1Idx, Vec<float, 2>{3.f, 0.f}},
+        };
+        return OpenABF::detail::lscm::buildSystem<float, LSCMSystemMesh>(mesh, pins);
     };
 
     auto parts1 = runOnce();

--- a/tests/src/TestParameterization.cpp
+++ b/tests/src/TestParameterization.cpp
@@ -1322,3 +1322,159 @@ TEST(LSCMSystemBuild, FreeIdxTable_DeterministicAcrossRuns)
     EXPECT_EQ(static_cast<std::size_t>(parts1.A.cols()), 2 * 14);
     EXPECT_EQ(static_cast<std::size_t>(parts2.A.cols()), 2 * 14);
 }
+
+// ============================================================================
+// A7 — Multi-pin (≥3 pins) tests for ABLSCM and HLSCM
+// ============================================================================
+
+TEST(Parameterization, AngleBasedLSCM_MultiPin_Pyramid)
+{
+    // Pin all three base vertices of the pyramid to a known equilateral
+    // triangle in UV space.  The apex (v3) is the only free vertex.
+    using LSCM = AngleBasedLSCM<float>;
+    using PinMap = typename LSCM::PinMap;
+
+    auto mesh = ConstructPyramid<LSCM::Mesh>();
+    PinMap pins{
+        {0u, Vec<float, 2>{0.f, 0.f}},
+        {1u, Vec<float, 2>{2.f, 0.f}},
+        {2u, Vec<float, 2>{1.f, std::sqrt(3.f)}},
+    };
+    LSCM::Compute(mesh, pins);
+
+    // Pinned vertices must land exactly at the specified UVs (z = 0).
+    for (const auto& [vIdx, uv] : pins) {
+        const auto& p = mesh->vertex(vIdx)->pos;
+        EXPECT_FLOAT_EQ(p[0], uv[0]) << "pin v" << vIdx << " u";
+        EXPECT_FLOAT_EQ(p[1], uv[1]) << "pin v" << vIdx << " v";
+        EXPECT_FLOAT_EQ(p[2], 0.f) << "pin v" << vIdx << " z";
+    }
+    // The free apex must be finite and in the z=0 plane.
+    const auto& apex = mesh->vertex(3)->pos;
+    EXPECT_TRUE(std::isfinite(apex[0]));
+    EXPECT_TRUE(std::isfinite(apex[1]));
+    EXPECT_FLOAT_EQ(apex[2], 0.f);
+}
+
+TEST(Parameterization, AngleBasedLSCM_SetPins_MatchesStatic)
+{
+    // The instance setPins() form must produce identical output to the static
+    // Compute(mesh, PinMap) overload for the same pins.
+    using LSCM = AngleBasedLSCM<float>;
+    using PinMap = typename LSCM::PinMap;
+
+    PinMap pins{
+        {0u, Vec<float, 2>{0.f, 0.f}},
+        {1u, Vec<float, 2>{2.f, 0.f}},
+        {2u, Vec<float, 2>{1.f, std::sqrt(3.f)}},
+    };
+
+    auto mesh_static = ConstructPyramid<LSCM::Mesh>();
+    LSCM::Compute(mesh_static, pins);
+
+    auto mesh_instance = ConstructPyramid<LSCM::Mesh>();
+    LSCM lscm;
+    lscm.setPins(pins);
+    lscm.compute(mesh_instance);
+
+    for (std::size_t v = 0; v < mesh_static->num_vertices(); ++v) {
+        const auto& vs = mesh_static->vertex(v)->pos;
+        const auto& vi = mesh_instance->vertex(v)->pos;
+        for (auto i = 0; i < 3; i++) {
+            EXPECT_FLOAT_EQ(vi[i], vs[i]) << "vertex " << v << " comp " << i;
+        }
+    }
+}
+
+TEST(HLSCM, MultiPin_Pyramid)
+{
+    // 4-vertex mesh: HLSCM falls back to single-level LSCM internally.  Pins
+    // must still land exactly at the requested UVs.
+    using HLSCM = HierarchicalLSCM<float>;
+    using PinMap = typename HLSCM::PinMap;
+
+    auto mesh = ConstructPyramid<HLSCM::Mesh>();
+    PinMap pins{
+        {0u, Vec<float, 2>{0.f, 0.f}},
+        {1u, Vec<float, 2>{2.f, 0.f}},
+        {2u, Vec<float, 2>{1.f, std::sqrt(3.f)}},
+    };
+    HLSCM::Compute(mesh, pins);
+
+    for (const auto& [vIdx, uv] : pins) {
+        const auto& p = mesh->vertex(vIdx)->pos;
+        EXPECT_FLOAT_EQ(p[0], uv[0]) << "pin v" << vIdx << " u";
+        EXPECT_FLOAT_EQ(p[1], uv[1]) << "pin v" << vIdx << " v";
+        EXPECT_FLOAT_EQ(p[2], 0.f) << "pin v" << vIdx << " z";
+    }
+    const auto& apex = mesh->vertex(3)->pos;
+    EXPECT_TRUE(std::isfinite(apex[0]));
+    EXPECT_TRUE(std::isfinite(apex[1]));
+    EXPECT_FLOAT_EQ(apex[2], 0.f);
+}
+
+TEST(HLSCM, MultiPin_Hemisphere)
+{
+    // 289-vertex mesh: exercises the multi-level hierarchy path.  Pin three
+    // equator vertices at chosen UVs and verify each lands exactly.  Pins
+    // must survive every decimation level (the isPinned_ flag protects them).
+    using HLSCM = HierarchicalLSCM<float>;
+    using PinMap = typename HLSCM::PinMap;
+
+    constexpr std::size_t rings = 12;
+    constexpr std::size_t sectors = 24;
+    auto mesh = ConstructHemisphere<HLSCM::Mesh>(rings, sectors);
+
+    // Equator ring indices: 1 + (rings-1)*sectors .. 1 + rings*sectors - 1
+    const std::size_t equatorBase = 1 + (rings - 1) * sectors;
+    PinMap pins{
+        {equatorBase + 0, Vec<float, 2>{0.f, 0.f}},
+        {equatorBase + sectors / 3, Vec<float, 2>{1.f, 0.f}},
+        {equatorBase + (2 * sectors) / 3, Vec<float, 2>{0.5f, 0.8660254f}},
+    };
+    HLSCM::Compute(mesh, pins);
+
+    for (const auto& [vIdx, uv] : pins) {
+        const auto& p = mesh->vertex(vIdx)->pos;
+        EXPECT_FLOAT_EQ(p[0], uv[0]) << "pin v" << vIdx << " u";
+        EXPECT_FLOAT_EQ(p[1], uv[1]) << "pin v" << vIdx << " v";
+        EXPECT_FLOAT_EQ(p[2], 0.f) << "pin v" << vIdx << " z";
+    }
+    // Every non-pinned vertex must have produced a finite UV in z=0 plane.
+    for (std::size_t v = 0; v < mesh->num_vertices(); ++v) {
+        const auto& pos = mesh->vertex(v)->pos;
+        EXPECT_TRUE(std::isfinite(pos[0])) << "vertex " << v << " u not finite";
+        EXPECT_TRUE(std::isfinite(pos[1])) << "vertex " << v << " v not finite";
+        EXPECT_FLOAT_EQ(pos[2], 0.f) << "vertex " << v << " z != 0";
+    }
+}
+
+TEST(HLSCM, SetPins_MatchesStatic)
+{
+    // Instance setPins() must produce identical output to the static
+    // Compute(mesh, PinMap) overload.
+    using HLSCM = HierarchicalLSCM<float>;
+    using PinMap = typename HLSCM::PinMap;
+
+    PinMap pins{
+        {0u, Vec<float, 2>{0.f, 0.f}},
+        {1u, Vec<float, 2>{2.f, 0.f}},
+        {2u, Vec<float, 2>{1.f, std::sqrt(3.f)}},
+    };
+
+    auto mesh_static = ConstructPyramid<HLSCM::Mesh>();
+    HLSCM::Compute(mesh_static, pins);
+
+    auto mesh_instance = ConstructPyramid<HLSCM::Mesh>();
+    HLSCM hlscm;
+    hlscm.setPins(pins);
+    hlscm.compute(mesh_instance);
+
+    for (std::size_t v = 0; v < mesh_static->num_vertices(); ++v) {
+        const auto& vs = mesh_static->vertex(v)->pos;
+        const auto& vi = mesh_instance->vertex(v)->pos;
+        for (auto i = 0; i < 3; i++) {
+            EXPECT_FLOAT_EQ(vi[i], vs[i]) << "vertex " << v << " comp " << i;
+        }
+    }
+}

--- a/tests/src/TestParameterization.cpp
+++ b/tests/src/TestParameterization.cpp
@@ -1480,8 +1480,7 @@ TEST(Parameterization, AngleBasedLSCM_PinMap_Rejects_Duplicate)
 
     auto mesh = ConstructPyramid<LSCM::Mesh>();
     PinMap pins{
-        {0u, Vec<float, 2>{0.f, 0.f}},
-        {0u, Vec<float, 2>{2.f, 0.f}},  // same index repeated
+        {0u, Vec<float, 2>{0.f, 0.f}}, {0u, Vec<float, 2>{2.f, 0.f}},  // same index repeated
     };
     EXPECT_THROW(LSCM::Compute(mesh, pins), std::invalid_argument);
 }
@@ -1493,8 +1492,7 @@ TEST(Parameterization, AngleBasedLSCM_PinMap_Rejects_OutOfRange)
 
     auto mesh = ConstructPyramid<LSCM::Mesh>();  // 4 vertices
     PinMap pins{
-        {0u, Vec<float, 2>{0.f, 0.f}},
-        {99u, Vec<float, 2>{2.f, 0.f}},  // out of range
+        {0u, Vec<float, 2>{0.f, 0.f}}, {99u, Vec<float, 2>{2.f, 0.f}},  // out of range
     };
     EXPECT_THROW(LSCM::Compute(mesh, pins), std::invalid_argument);
 }


### PR DESCRIPTION
Closes #42.

## Summary
- Adds N-pin (N ≥ 2) UV constraints to both `AngleBasedLSCM` and
  `HierarchicalLSCM` via a new `PinMap` API (`Compute(mesh, PinMap)`,
  `set_pins(PinMap)`). Pinned vertices land exactly at their specified UVs.
- Migrates `detail::lscm::buildSystem` to a single PinMap-based signature
  (no pin-write side-effect; caller controls where UVs are written).
- HLSCM multi-pin works end-to-end. `DecimationMesh::build` now takes a
  vector of pin indices and flags each as non-collapsible; `tryCollapse`
  already keyed off `isPinned_`, so pins survive every hierarchy level by
  construction. `solveLSCMLevel` takes a PinMap and maps each pin's
  original idx to its level-local idx.
- HLSCM single-level fallback delegates to `AngleBasedLSCM::Compute` with
  the same PinMap, preserving exact equivalence on small meshes.

## Deprecation
The 2-pin API (`Compute(mesh, p0, p1)`, `setPinnedVertices(p0, p1)`) is
retained as `[[deprecated]]` shims on both classes. The shims build an
axis-snap PinMap (origin + dominant-axis convention) and delegate to the
multi-pin path. **Slated for removal in 3.0.** Existing 2-pin call sites
continue to work unchanged with a deprecation warning.

## API surface
```cpp
// New (preferred)
using PinMap = std::vector<std::pair<std::size_t, Vec<T, 2>>>;
static void Compute(const mesh&, const PinMap&);
void set_pins(const PinMap&);

// Detail helpers (public for testing)
void ValidatePins(const mesh&, const PinMap&);
auto AutoPlacePair(const mesh&, std::size_t p0, std::size_t p1) -> PinMap<T>;
auto AutoSelectPins(const mesh&) -> PinMap<T>;

// Deprecated (removed in 3.0)
[[deprecated]] static void Compute(const mesh&, std::size_t p0, std::size_t p1);
[[deprecated]] void setPinnedVertices(std::size_t p0, std::size_t p1);
```

## Review fixes
- HLSCM instance-path validation: `compute()` now calls `ValidatePins` when
  `pins_` is set, preventing out-of-bounds writes.
- Deprecated 2-pin shims now validate via `AutoPlacePair`, throwing
  `std::invalid_argument` on out-of-range or same-index pairs (fixes NaN trap).
- Deduplication: moved `AutoPlacePair` and `ValidatePins` into `detail::lscm`,
  eliminating ~80 lines of near-identical code across the classes.
- Mesh purity: removed pin-write side-effect from `buildSystem`; ABLSCM
  writes pin UVs in its writeback loop, HLSCM never relied on it.
- Checked unwrap of `level.originalToLocal[origIdx]` in HLSCM, throwing
  `SolverException` if a pinned vertex was unexpectedly removed during
  decimation.

## Naming convention
Aligned new code with codebase convention (PascalCase for free functions,
lower_snake_case for instance methods). Pre-existing camelCase items
(e.g., `buildSystem`, `detail::hlscm::*`, `setLevelRatio`) tracked in #94.

## Test plan
- [x] All 60 parameterization assertions pass (6/6 test binaries via `ctest`).
      Was 50 before this PR — 10 new tests added.
- [x] New multi-pin tests:
  - `AngleBasedLSCM_MultiPin_Pyramid` — 3 pins, exact UV landing.
  - `AngleBasedLSCM_MultiPin_FourPins_Grid` — 4 pins on grid.
  - `AngleBasedLSCM_SetPins_MatchesStatic` — instance/static parity.
  - `AngleBasedLSCM_SetPins_OverridesSetPinnedVertices` — multi-pin override.
  - `HLSCM.MultiPin_Pyramid` — single-level fallback path.
  - `HLSCM.MultiPin_Hemisphere` — multi-level hierarchy (289 verts, pins on
    equator survive every decimation level).
  - `HLSCM.MultiPin_FourPins_Grid` — 4 pins on grid.
  - `HLSCM.SetPins_MatchesStatic` — instance/static parity.
- [x] New validation tests:
  - `AngleBasedLSCM_PinMap_Rejects_OutOfRange` — static Compute with bad index.
  - `HLSCM.PinMap_Rejects_OutOfRange` — static Compute with bad index.
  - `HLSCM.Instance_PinMap_Rejects_OutOfRange` — regression guard for
    instance `set_pins` path.
- [x] Existing `AngleBasedLSCM_ExplicitPins`, `_Reversed`,
  `_SetPinnedVertices`, `HLSCM.ExplicitPins`, `HLSCM.SetPinnedVertices` now
  exercise the deprecated-shim path and continue to pass.
- [x] `LSCMSystemBuild.*` tests migrated to new `buildSystem(mesh, PinMap)`
  signature.
- [x] Internal `HLSCMInternal.*` tests migrated to new
  `DecimationMesh::build(indices)` and PinMap signatures.
- [x] `git clang-format` clean; single-header amalgamation regenerated.